### PR TITLE
Add readme with organization and repository details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# 
+
+Coordination and documents for [Name], a worker co-operative based out of Ontario, Canada.
+
+This repository currently contains: 
+- notes from working group and all hands meetings
+- summary documents from member retreats
+
+## Mission and Vision
+
+*[Name] Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
+
+Working in solidarity with our neighbours, we support each other and provide safe harbour to imagine and create alternative futures.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 
 
-Coordination and documents for [Name], a worker co-operative based out of Ontario, Canada.
+Coordination and documents for Hypha, a worker co-operative based out of Ontario, Canada.
 
 This repository currently contains: 
 - notes from working group and all hands meetings
@@ -8,6 +8,6 @@ This repository currently contains:
 
 ## Mission and Vision
 
-*[Name] Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
+*Hypha Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
 
 Working in solidarity with our neighbours, we support each other and provide safe harbour to imagine and create alternative futures.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,4 @@ Coordination and documents for Hypha, a worker co-operative based out of Ontario
 
 This repository currently contains: 
 - notes from working group and all hands meetings
-- summary documents from member retreats
-
-## Mission and Vision
-
-*Hypha Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
-
-Working in solidarity with our neighbours, we support each other and provide safe harbour to imagine and create alternative futures.
+- summary documents from our member retreat in December 2018


### PR DESCRIPTION
Got impatient and started a **WIP** PR for

- adding a readme
- ~adding mission and vision, closes #24~ (removed in favour of https://github.com/hyphacoop/handbook)
- codifying the renamed repo, partially addresses #23 

... and more
