### PR TITLE
Generalized retreat doc title

### DIFF
--- a/2018-retreat/2018-11-28-retreat-playbook.md
+++ b/2018-retreat/2018-11-28-retreat-playbook.md
@@ -1,5 +1,5 @@
-:palm_tree: Cryptography.dog Retreat Playbook :palm_tree:
-=========================================================
+:palm_tree: Tech Worker Co-op Retreat Playbook :palm_tree:
+==========================================================
 
 **Status**: *Finalized Nov 28, 2018*  
 After finalization, all members can fork their own hackpad copy for using the playbook.


### PR DESCRIPTION
It seems a bit confusing to share with the cryptography.dog name.

Decided not to use Hypha, as feels important that we ran this much much much before incorporating or name, and would rather not mislead on that point. Open to alternative perspectives!