### PR TITLE
Use link.hypha.coop conventions in template

### DIFF
--- a/-meeting-template.md
+++ b/-meeting-template.md
@@ -2,7 +2,7 @@
 
 <sup>[from template][template]</sup>
 
-[:date: Calendar][cal] | [:cat: GitHub][gh] | [:open_file_folder: GDrive][gdrive] | [:notebook: Meeting Index][meetings]
+[:date: Calendar][calendar] | [:cat: GitHub][gh] | [:open_file_folder: GDrive][gdrive] | [:notebook: Meeting Index][meetings]
 
 Time: ...  
 Location: https://meet.jit.si/hyphacoop  
@@ -23,7 +23,7 @@ Notetaker: ...
     - [Business Planning][biz-wg]
     - [Finance][fin-wg]
     - [Governance][gov-wg]
-    - [Infra & Ops][ino-wg]
+    - [Infra & Ops][ops-wg]
 - Discussion
     ...
 
@@ -48,10 +48,10 @@ Notetaker: ...
 <!-- Links -->
 [template]: https://link.hypha.coop/template
 [meetings]: https://link.hypha.coop/meetings
-[cal]: https://calendar.google.com/calendar/embed?src=s2224p8sptnujs736vplf9anjo%40group.calendar.google.com&ctz=America%2FToronto
+[calendar]: https://link.hypha.coop/calendar
 [gh]: https://github.com/hyphacoop/organizing
-[gdrive]: https://drive.google.com/drive/u/0/folders/14KYnYwOEK3InYZ3jCn-Gtf5q430sE9oc
-[biz-wg]: https://loomio.hypha.coop/g/ojZI2bPl/working-groups-business-planning
-[fin-wg]: https://loomio.hypha.coop/g/sRPwaorg/working-groups-finance
-[gov-wg]: https://loomio.hypha.coop/g/BaAj6dQn/working-groups-governance-by-laws-incorporation-articles-gm-
-[ino-wg]: https://loomio.hypha.coop/g/KvARWad7/working-groups-infrastructure-and-operations
+[gdrive]: https://link.hypha.coop/gdrive
+[biz-wg]: https://link.hypha.coop/biz-wg
+[fin-wg]: https://link.hypha.coop/fin-wg
+[gov-wg]: https://link.hypha.coop/gov-wg
+[ops-wg]: https://link.hypha.coop/ops-wg


### PR DESCRIPTION
Just wanted to demonstrate how commons links can start becoming easier to find. No rush to merge this until we have the infra convo and an official proposal

Also, bonus: created a little screencast to show how easy navigating them becomes when you use custom browser search engines :)

![screenshot of adding/using shortlinks as keywords with custom search engine set in browser](https://i.imgur.com/2D8B7kS.gif)