### PR TITLE
Add issue template for tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/task_template.md
+++ b/.github/ISSUE_TEMPLATE/task_template.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: Create a high-level organizational task
+---
+Re-ticketed from #
+
+## Shared Description
+
+:speaking_head: **Loomio:** N/A
+:dart: **Success criteria:** ...
+
+## To Do
+
+- [ ] ...

--- a/.github/ISSUE_TEMPLATE/task_template.md
+++ b/.github/ISSUE_TEMPLATE/task_template.md
@@ -6,8 +6,9 @@ Re-ticketed from #
 
 ## Shared Description
 
-:speaking_head: **Loomio:** N/A
-:dart: **Success criteria:** ...
+:speaking_head: **Loomio:** N/A  
+:date: **Due date:** N/A  
+:dart: **Success criteria:** ...  
 
 ## To Do
 


### PR DESCRIPTION
Here's the logic here:

- optional **re-ticketing** bit was something I picked up from Gittip, where breaking down tickets and keeping them granular was encouraged, and tying them together was important. If it's not the case, creator just deletes this bit from issue stub.
  - example: https://github.com/hyphacoop/organizing/issues/87
- **shared description** header is about communicating that be body of the issue starter post is not "owned" by the person whose avatar shows up on the ticket, but rather it's open for anyone to edit. (much like how trello and loomio lean toward)
- **Loomio link** is to encourage all tickets to have a discussion context. The idea was that github issues would be only for the most basic of convo around tasks. Loomio issues are not meant to be 1:1 with github issues, but the loomio thread is probably _the_ place where you want to get into larger convos about the ticket.
- **success criteria** something i picked up from agile at myplanet. There was issue with creating long-standing tickets which could hang around forever. Explicitly defining "success" allowed anyone, even people who didn't understand what needed doing, to **help see if scope is too big, and so ticket could be broken down further.**
  - example: https://github.com/hyphacoop/organizing/issues/66

Thoughts or feedback on any of the above?