### PR TITLE
Add ability to render HTML with emoji

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,17 @@
+plugins:
+  - jemoji
+
+# Allows full rendering with autolinks and tasklists.
+# See: https://github.com/github/jekyll-commonmark-ghpages#installation
+markdown: CommonMarkGhPages
+
+commonmark:
+  options: ["SMART", "FOOTNOTES"]
+  extensions:
+    - "strikethrough"
+    - "autolink"
+    - "table"
+    - "tagfilter"
+    # This will start working when commonmarker is upgraded.
+    # See: https://github.com/github/jekyll-commonmark-ghpages/issues/13
+    - "tasklist"


### PR DESCRIPTION
This will let us better render agendas as HTML pages via GitHub Pages.

For example: https://hackmd.io/@patcon/ryMxS3okB/https%3A%2F%2Fhyphacoop.github.io%2Forganizing%2F2019-10-30-all-hands-meeting.html?type=book