### PR TITLE
Improve templates: linebreaks and docs

### DIFF
--- a/-meeting-template.md
+++ b/-meeting-template.md
@@ -1,5 +1,7 @@
 ---
-private: false
+breaks:  false # See: https://github.com/hackmdio/codimd/issues/40#issuecomment-172927690
+private: false # See: https://github.com/hyphacoop/hyphacoop-chatbot#archive
+
 ---
 # YYYY-MM-DD Hypha Worker Co-op: All Hands Meeting
 

--- a/-meeting-template.md
+++ b/-meeting-template.md
@@ -1,7 +1,6 @@
 ---
 breaks:  false # See: https://github.com/hackmdio/codimd/issues/40#issuecomment-172927690
 private: false # See: https://github.com/hyphacoop/hyphacoop-chatbot#archive
-
 ---
 # YYYY-MM-DD Hypha Worker Co-op: All Hands Meeting
 

--- a/-standup-template.md
+++ b/-standup-template.md
@@ -1,5 +1,7 @@
 ---
-private: false
+breaks:  false # See: https://github.com/hackmdio/codimd/issues/40#issuecomment-172927690
+private: false # See: https://github.com/hyphacoop/hyphacoop-chatbot#archive
+
 ---
 # YYYY-MM-DD Hypha Worker Co-op: Standup Meeting
 


### PR DESCRIPTION
Code and linkes should explain themselves, but gist is that with this setting, then we don't have to worry about note line-endings rendering different when they migrate to github :)