### PR TITLE
Ensure labels only sync on commits to github action config

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -5,7 +5,7 @@ on:
     types: [created, edited, deleted]
   push:
     paths:
-      - .github/workflows/*.yml
+      - .github/workflows/sync-labels.yml
     branches:
       - master
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,6 +4,8 @@ on:
   label:
     types: [created, edited, deleted]
   push:
+    paths:
+      - .github/workflows/*.yml
     branches:
       - master
 


### PR DESCRIPTION
Prevents noisy label syncs like this when modifying content in repo:
https://github.com/hyphacoop/organizing/issues/145#issuecomment-565386867