### PR TITLE
Add helpful link to see own recent github activity

### DIFF
--- a/-standup-template.md
+++ b/-standup-template.md
@@ -18,6 +18,8 @@ Notetaker:  ... :raising_hand: Next up: COPY FROM PAST WEEK
   1. What did you work on this past week?
   2. What do you plan to work on this coming week?
   3. What are your blockers?
+  
+**Helpful link:** https://github.com/issues?q=org:hyphacoop+sort:updated-desc+involves:YOU
 
 ## Standup Notes
 


### PR DESCRIPTION
Makes it simpler to remember what you did this week.

![Screenshot at 18-00-57](https://user-images.githubusercontent.com/305339/72475320-0cbab580-37c1-11ea-93b4-7161767b0ba2.png)


Related: https://github.com/isaacs/github/issues/1293