### PR TITLE
Prevent templates from indexing by default

### DIFF
--- a/-meeting-template.md
+++ b/-meeting-template.md
@@ -1,6 +1,7 @@
 ---
 breaks:  false # See: https://github.com/hackmdio/codimd/issues/40#issuecomment-172927690
 private: false # See: https://github.com/hyphacoop/hyphacoop-chatbot#archive
+robots: noindex, nofollow, noarchive, nocache
 ---
 # YYYY-MM-DD Hypha Worker Co-op: All Hands Meeting
 


### PR DESCRIPTION
Just to be safe, in case we miss locking down something that should be.

https://hackmd.io/s/features#YAML-Metadata
https://moz.com/learn/seo/robots-meta-directives