### PR TITLE
Fix and DRY out private notes link page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,13 @@ defaults:
       type: "posts" # previously `post` in Jekyll 2.2.
     values:
       layout: "default"
+  -
+    scope:
+      type: "posts"
+      #path: "_posts/private/*/*"
+      path: "_posts/private/meeting-notes/2020-03-09-infrastructure.md"
+    values:
+      layout: "private"
 
 # External repository where private documents are available with access restriction
 organizing-private: https://github.com/hyphacoop/organizing-private/blob/master

--- a/_config.yml
+++ b/_config.yml
@@ -58,7 +58,7 @@ defaults:
       layout: "default"
 
 # External repository where private documents are available with access restriction
-organizing-private: https://github.com/hyphacoop/organizing-private/blob/site
+organizing-private: https://github.com/hyphacoop/organizing-private/blob/master
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_includes/private_redirect.html
+++ b/_includes/private_redirect.html
@@ -1,0 +1,5 @@
+Oops! The notes from **{{ include.page.date | date: "%Y-%m-%d" }} {{ include.page.title }}** is not open to public :lock:
+
+If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ include.page.path | replace: '/private/', '/' }}">**view the notes here**</a> :key:
+
+Please see the _Working Open_ guidelines in our [Handbook](https://handbook.hypha.coop/working-open.html).

--- a/_includes/private_redirect.md
+++ b/_includes/private_redirect.md
@@ -1,5 +1,5 @@
 Oops! The notes from **{{ include.page.date | date: "%Y-%m-%d" }} {{ include.page.title }}** is not open to public :lock:
 
-If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ include.page.path | replace: '/private/', '/' }}">**view the notes here**</a> :key:
+If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ include.page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
 
 Please see the _Working Open_ guidelines in our [Handbook](https://handbook.hypha.coop/working-open.html).

--- a/_includes/private_redirect.md
+++ b/_includes/private_redirect.md
@@ -1,5 +1,5 @@
-Oops! The notes from **{{ include.page.date | date: "%Y-%m-%d" }} {{ include.page.title }}** is not open to public :lock:
+Oops! The notes from **{{ page.date | date: "%Y-%m-%d" }} {{ page.title }}** is not open to public :lock:
 
-If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ include.page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
+If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
 
 Please see the _Working Open_ guidelines in our [Handbook](https://handbook.hypha.coop/working-open.html).

--- a/_layouts/private.html
+++ b/_layouts/private.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  {%- include head.html -%}
+
+  <body>
+
+    <main class="page-content" aria-label="Content">
+
+        <div class="wrapper">
+          {% capture private_redirect %}{% include private_redirect.md page=page %}{% endcapture %}
+          {{ private_redirect | markdownify }}
+          {{ content }}
+        </div>
+
+        <div class="nav">
+
+          <ul>
+            <h2>Meeting Notes</h2>
+              <li>
+                <a href="https://hackmd.io/d0lpI2sNTJOtvLlE4_86Cg?edit">All Hands: Full</a> :seedling:
+                <a href="https://link.hypha.coop/template" target="_blank"><span class="small light">template</span></a>
+              </li>
+              <li>
+                <a href="https://hackmd.io/LXg-o9b7QIO_lyeHPirH8A?edit">All Hands: Standup</a> :seedling:
+                <a href="https://link.hypha.coop/standup-template" target="_blank"><span class="small light">template</span></a>
+              </li>
+              <li>
+                <a href="https://hackmd.io/1JMsZ8IdSb6bp4VFB1dUtw?edit">WG: Business Planning</a> :seedling:
+                <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+              </li>
+              <li>
+                <a href="https://hackmd.io/YclYMO0KTT2n_5xmArdMDA?edit">WG: Finance</a> :seedling:
+                <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+              </li>
+              <li>
+                <a href="https://hackmd.io/JT5qnRwnTs6J3vLlf4UyFA?edit">WG: Governance</a> :seedling:
+                <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+              </li>
+              <li>
+                <a href="https://hackmd.io/C8uSvttkR1OaQWFNcRQWvQ?edit">WG: Infrastructure</a> :seedling:
+                <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+              </li>
+              <li>
+                <span class="small">Archive as</span>
+                <a href="https://github.com/hyphacoop/organizing/new/master?filename=_posts/meeting-notes/2020-MM-DD-.md" target="_blank"><span class="small">open access</span></a>
+              </li>
+              <li>
+                <span class="small">Archive as</span>
+                <a href="https://github.com/hyphacoop/organizing/new/master?filename=_posts/private/meeting-notes/2020-MM-DD-standup.md&value=Oops%21%20The%20notes%20from%20%2A%2A%7B%7B%20page.date%20%7C%20date%3A%20%22%25Y-%25m-%25d%22%20%7D%7D%20%7B%7B%20page.title%20%7D%7D%2A%2A%20is%20not%20open%20to%20public%20%3Alock%3A%0A%0AIf%20you%20have%20privileged%20access%2C%20you%20can%20%3Ca%20href%3D%22%7B%7B%20site.organizing-private%20%7D%7D%2F%7B%7B%20page.path%20%7C%20remove%3A%20%27_posts%2Fprivate%2F%27%20%7D%7D%22%3E%2A%2Aview%20the%20notes%20here%2A%2A%3C%2Fa%3E%20%3Akey%3A%0A%0APlease%20see%20the%20_Working%20Open_%20guidelines%20in%20our%20%5BHandbook%5D%28https%3A%2F%2Fhandbook.hypha.coop%2Fworking-open.html%29." target="_blank"><span class="small">publicly indexed</span></a>
+                <span class="small">with</span>
+                <a href="https://github.com/hyphacoop/organizing-private/new/master?filename=_posts/meeting-notes/2020-MM-DD-.md" target="_blank"><span class="small">restricted access</span></a>
+              </li>
+          </ul>
+
+          <ul>
+            <h3>Archived</h3>
+            {% for post in site.posts %}
+              {% if post.path contains "private/meeting-notes/" %}
+                <li>
+                  <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a> :lock:
+                </li>
+              {% elsif post.path contains "meeting-notes/" %}
+                <li>
+                  <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+
+          <ul>
+            <h3>Informational Interviews</h3>
+            {% for post in site.posts %}
+              {% if post.path contains "private/informational-interviews/" %}
+                <li>
+                  <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a> :lock:
+                </li>
+              {% elsif post.path contains "informational-interviews/" %}
+                <li>
+                  <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+
+          <ul>
+            <h3>2018 December Retreat</h3>
+            {% for post in site.posts %}
+              {% if post.path contains "2018-december-retreat/" %}
+                <li>
+                  <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+
+        </div>
+
+    </main>
+
+  </body>
+
+</html>

--- a/_layouts/private.html
+++ b/_layouts/private.html
@@ -8,7 +8,9 @@
     <main class="page-content" aria-label="Content">
 
         <div class="wrapper">
-          {% capture private_redirect %}{% include private_redirect.md page=page %}{% endcapture %}
+          {% capture private_redirect -%}
+            {% include private_redirect.md %}
+          {%- endcapture %}
           {{ private_redirect | markdownify }}
           {{ content }}
         </div>

--- a/_posts/private/meeting-notes/2020-03-09-infrastructure.md
+++ b/_posts/private/meeting-notes/2020-03-09-infrastructure.md
@@ -1,5 +1,0 @@
-Oops! The notes from **{{ page.date | date: "%Y-%m-%d" }} {{ page.title }}** is not open to public :lock:
-
-If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
-
-Please see the _Working Open_ guidelines in our [Handbook](https://handbook.hypha.coop/working-open.html).

--- a/_posts/private/meeting-notes/2020-03-12-business-planning.md
+++ b/_posts/private/meeting-notes/2020-03-12-business-planning.md
@@ -1,2 +1,2 @@
-{% include private_redirect.html page=page %}
+{% include private_redirect.md page=page %}
 

--- a/_posts/private/meeting-notes/2020-03-12-business-planning.md
+++ b/_posts/private/meeting-notes/2020-03-12-business-planning.md
@@ -1,2 +1,2 @@
-{% include private_redirect.md page=page %}
+{% include private_redirect.md %}
 

--- a/_posts/private/meeting-notes/2020-03-12-business-planning.md
+++ b/_posts/private/meeting-notes/2020-03-12-business-planning.md
@@ -1,5 +1,2 @@
-Oops! The notes from **{{ page.date | date: "%Y-%m-%d" }} {{ page.title }}** is not open to public :lock:
+{% include private_redirect.html page=page %}
 
-If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
-
-Please see the _Working Open_ guidelines in our [Handbook](https://handbook.hypha.coop/working-open.html).


### PR DESCRIPTION
For example, notes page over here was broken, due to folder structure changing:
https://meetings.hypha.coop/2020-03-12-business-planning.html

Seems onerous to update all these when we move things around, so using _includes to make it updateable in one place.

If it looks good, we can do it for the rest, and update the GitHub PR links.