### PR TITLE
Slight nav rearrangement and fixing non-W3C html

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,7 +64,8 @@ defaults:
       layout: "private"
 
 # External repository where private documents are available with access restriction
-organizing-private: https://github.com/hyphacoop/organizing-private/blob/master
+private-repo-url: https://github.com/hyphacoop/organizing-private
+public-repo-url: https://github.com/hyphacoop/organizing
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,14 @@ defaults:
 private-repo-url: https://github.com/hyphacoop/organizing-private
 public-repo-url: https://github.com/hyphacoop/organizing
 
+nav-sections:
+  - title: Archived
+    path: meeting-notes/
+  - title: Informational Interviews
+    path: informational-interviews/
+  - title: 2018 December Retreat
+    path: 2018-december-retreat/
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,27 +4,27 @@
   <ul>
     <li>
       <a href="https://hackmd.io/d0lpI2sNTJOtvLlE4_86Cg?edit">All Hands: Full</a> :seedling:
-      <a href="https://link.hypha.coop/template" target="_blank"><span class="small light">template</span></a>
+      <a href="https://link.hypha.coop/template" target="_blank" class="small light">template</a>
     </li>
     <li>
       <a href="https://hackmd.io/LXg-o9b7QIO_lyeHPirH8A?edit">All Hands: Standup</a> :seedling:
-      <a href="https://link.hypha.coop/standup-template" target="_blank"><span class="small light">template</span></a>
+      <a href="https://link.hypha.coop/standup-template" target="_blank" class="small light">template</a>
     </li>
     <li>
       <a href="https://hackmd.io/1JMsZ8IdSb6bp4VFB1dUtw?edit">WG: Business Planning</a> :seedling:
-      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+      <a href="https://link.hypha.coop/wg-template" target="_blank" class="small light">template</a>
     </li>
     <li>
       <a href="https://hackmd.io/YclYMO0KTT2n_5xmArdMDA?edit">WG: Finance</a> :seedling:
-      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+      <a href="https://link.hypha.coop/wg-template" target="_blank" class="small light">template</a>
     </li>
     <li>
       <a href="https://hackmd.io/JT5qnRwnTs6J3vLlf4UyFA?edit">WG: Governance</a> :seedling:
-      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+      <a href="https://link.hypha.coop/wg-template" target="_blank" class="small light">template</a>
     </li>
     <li>
       <a href="https://hackmd.io/C8uSvttkR1OaQWFNcRQWvQ?edit">WG: Infrastructure</a> :seedling:
-      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+      <a href="https://link.hypha.coop/wg-template" target="_blank" class="small light">template</a>
     </li>
     <li>
       <span class="small">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -27,14 +27,18 @@
         <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
       </li>
       <li>
-        <span class="small">Archive as</span>
-        <a href="https://github.com/hyphacoop/organizing/new/master?filename=_posts/meeting-notes/2020-MM-DD-.md" target="_blank"><span class="small">open access</span></a>
+        <span class="small">
+          Archive as
+          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/meeting-notes/2020-MM-DD-.md" target="_blank">open access</a>
+        </span>
       </li>
       <li>
-        <span class="small">Archive as</span>
-        <a href="https://github.com/hyphacoop/organizing/new/master?filename=_posts/private/meeting-notes/2020-MM-DD-standup.md&value=Empty%20file%20for%20public%20indexing%20of%20access-restricted%20file." target="_blank"><span class="small">publicly indexed</span></a>
-        <span class="small">with</span>
-        <a href="https://github.com/hyphacoop/organizing-private/new/master?filename=meeting-notes/2020-MM-DD-.md" target="_blank"><span class="small">restricted access</span></a>
+        <span class="small">
+          Archive as
+          <a href="{{ site.private-repo-url }}/new/master?filename=meeting-notes/2020-MM-DD-.md" target="_blank">restricted access</a>
+          with
+          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/private/meeting-notes/2020-MM-DD-standup.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
+        </span>
       </li>
   </ul>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,49 +1,49 @@
 <div class="nav">
 
+  <h2>Meeting Notes</h2>
   <ul>
-    <h2>Meeting Notes</h2>
-      <li>
-        <a href="https://hackmd.io/d0lpI2sNTJOtvLlE4_86Cg?edit">All Hands: Full</a> :seedling:
-        <a href="https://link.hypha.coop/template" target="_blank"><span class="small light">template</span></a>
-      </li>
-      <li>
-        <a href="https://hackmd.io/LXg-o9b7QIO_lyeHPirH8A?edit">All Hands: Standup</a> :seedling:
-        <a href="https://link.hypha.coop/standup-template" target="_blank"><span class="small light">template</span></a>
-      </li>
-      <li>
-        <a href="https://hackmd.io/1JMsZ8IdSb6bp4VFB1dUtw?edit">WG: Business Planning</a> :seedling:
-        <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
-      </li>
-      <li>
-        <a href="https://hackmd.io/YclYMO0KTT2n_5xmArdMDA?edit">WG: Finance</a> :seedling:
-        <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
-      </li>
-      <li>
-        <a href="https://hackmd.io/JT5qnRwnTs6J3vLlf4UyFA?edit">WG: Governance</a> :seedling:
-        <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
-      </li>
-      <li>
-        <a href="https://hackmd.io/C8uSvttkR1OaQWFNcRQWvQ?edit">WG: Infrastructure</a> :seedling:
-        <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
-      </li>
-      <li>
-        <span class="small">
-          Archive as
-          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/meeting-notes/2020-MM-DD-.md" target="_blank">open access</a>
-        </span>
-      </li>
-      <li>
-        <span class="small">
-          Archive as
-          <a href="{{ site.private-repo-url }}/new/master?filename=meeting-notes/2020-MM-DD-.md" target="_blank">restricted access</a>
-          with
-          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/private/meeting-notes/2020-MM-DD-standup.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
-        </span>
-      </li>
+    <li>
+      <a href="https://hackmd.io/d0lpI2sNTJOtvLlE4_86Cg?edit">All Hands: Full</a> :seedling:
+      <a href="https://link.hypha.coop/template" target="_blank"><span class="small light">template</span></a>
+    </li>
+    <li>
+      <a href="https://hackmd.io/LXg-o9b7QIO_lyeHPirH8A?edit">All Hands: Standup</a> :seedling:
+      <a href="https://link.hypha.coop/standup-template" target="_blank"><span class="small light">template</span></a>
+    </li>
+    <li>
+      <a href="https://hackmd.io/1JMsZ8IdSb6bp4VFB1dUtw?edit">WG: Business Planning</a> :seedling:
+      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+    </li>
+    <li>
+      <a href="https://hackmd.io/YclYMO0KTT2n_5xmArdMDA?edit">WG: Finance</a> :seedling:
+      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+    </li>
+    <li>
+      <a href="https://hackmd.io/JT5qnRwnTs6J3vLlf4UyFA?edit">WG: Governance</a> :seedling:
+      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+    </li>
+    <li>
+      <a href="https://hackmd.io/C8uSvttkR1OaQWFNcRQWvQ?edit">WG: Infrastructure</a> :seedling:
+      <a href="https://link.hypha.coop/wg-template" target="_blank"><span class="small light">template</span></a>
+    </li>
+    <li>
+      <span class="small">
+        Archive as
+        <a href="{{ site.public-repo-url }}/new/master?filename=_posts/meeting-notes/2020-MM-DD-.md" target="_blank">open access</a>
+      </span>
+    </li>
+    <li>
+      <span class="small">
+        Archive as
+        <a href="{{ site.private-repo-url }}/new/master?filename=meeting-notes/2020-MM-DD-.md" target="_blank">restricted access</a>
+        with
+        <a href="{{ site.public-repo-url }}/new/master?filename=_posts/private/meeting-notes/2020-MM-DD-standup.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
+      </span>
+    </li>
   </ul>
 
+  <h3>Archived</h3>
   <ul>
-    <h3>Archived</h3>
     {% for post in site.posts %}
       {% if post.path contains "private/meeting-notes/" %}
         <li>
@@ -57,8 +57,8 @@
     {% endfor %}
   </ul>
 
+  <h3>Informational Interviews</h3>
   <ul>
-    <h3>Informational Interviews</h3>
     {% for post in site.posts %}
       {% if post.path contains "private/informational-interviews/" %}
         <li>
@@ -72,8 +72,8 @@
     {% endfor %}
   </ul>
 
+  <h3>2018 December Retreat</h3>
   <ul>
-    <h3>2018 December Retreat</h3>
     {% for post in site.posts %}
       {% if post.path contains "2018-december-retreat/" %}
         <li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<div class="nav">
+<nav>
 
   <h2>Meeting Notes</h2>
   <ul>
@@ -42,45 +42,22 @@
     </li>
   </ul>
 
-  <h3>Archived</h3>
-  <ul>
-    {% for post in site.posts %}
-      {% if post.path contains "private/meeting-notes/" %}
-        <li>
-          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a> :lock:
-        </li>
-      {% elsif post.path contains "meeting-notes/" %}
-        <li>
-          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
+  {% for section in site.nav-sections %}
+    <h3>{{ section.title }}</h3>
+    <ul>
+      {% for post in site.posts %}
+        {% capture private_path %}private/{{ section.path }}{% endcapture %}
+        {% if post.path contains private_path %}
+          <li>
+            <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a> :lock:
+          </li>
+        {% elsif post.path contains section.path %}
+          <li>
+            <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  {% endfor %}
 
-  <h3>Informational Interviews</h3>
-  <ul>
-    {% for post in site.posts %}
-      {% if post.path contains "private/informational-interviews/" %}
-        <li>
-          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a> :lock:
-        </li>
-      {% elsif post.path contains "informational-interviews/" %}
-        <li>
-          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-
-  <h3>2018 December Retreat</h3>
-  <ul>
-    {% for post in site.posts %}
-      {% if post.path contains "2018-december-retreat/" %}
-        <li>
-          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.date | date: "%Y-%m-%d" }} {{ post.title }}</a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-
-</div>
+</nav>

--- a/_includes/private-redirect.html
+++ b/_includes/private-redirect.html
@@ -1,5 +1,5 @@
 Oops! The notes from **{{ page.date | date: "%Y-%m-%d" }} {{ page.title }}** is not open to public :lock:
 
-If you have privileged access, you can <a href="{{ site.organizing-private }}/{{ page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
+If you have privileged access, you can <a href="{{ site.private-repo-url }}/blob/master/{{ page.path | remove: '_posts/private/' }}">**view the notes here**</a> :key:
 
 Please see the _Working Open_ guidelines in our [Handbook](https://handbook.hypha.coop/working-open.html).

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -18,6 +18,10 @@
   width: 30%;
   height: 100%;
 
+  h2, h3 {
+    margin-left: 30px;
+  }
+
   ul {
     list-style-type: none;
   }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -11,7 +11,7 @@
   height: 100%;
 }
 
-.nav {
+nav {
   position: relative;
   float: right;
   overflow: auto;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -31,6 +31,6 @@
   font-size: 0.75em;
 }
 
-.light {
-  color: #ccc;
+a.light {
+    color: #ccc;
 }


### PR DESCRIPTION
First commit is:
- switching order of archive links
- moving private and public repo urls in config vars

then just moving html element to pass w3c spec and get the styling ben presumably wanted :)

<img width="332" alt="Screen Shot 2020-03-18 at 10 36 57 PM" src="https://user-images.githubusercontent.com/305339/77026022-07b4e680-6969-11ea-89f6-0cbe7f92f824.png">
