### PR TITLE
Auto-linked GH issues from past meeting notes

### DIFF
--- a/_posts/meeting-notes/2019-01-21-finance-wg.md
+++ b/_posts/meeting-notes/2019-01-21-finance-wg.md
@@ -37,12 +37,12 @@ Notetaker:  bl
 - Triage new tasks
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 
-- #156 payroll, WagePoint doesn't work with our QBO plan
+- [#156](https://github.com/hyphacoop/organizing/issues/156) payroll, WagePoint doesn't work with our QBO plan
     - can have Rodica do this for us
     - Rodica has access to our books, but is waiting on us
     - pc, yj: have Rodica do the first integration
     - DECISION: don't upgrade QBO account for now
-- #122 get clarity with Rodica, to not leave contract undefined
+- [#122](https://github.com/hyphacoop/organizing/issues/122) get clarity with Rodica, to not leave contract undefined
     - pc: plan to export payroll then talk to Rodica
     - bl: emphasize I want alignment on scope of work and budget, don't feel we must have contract to start
     - #todo ask expected monthly rate (pc)

--- a/_posts/meeting-notes/2019-02-05-all-hands-meeting.md
+++ b/_posts/meeting-notes/2019-02-05-all-hands-meeting.md
@@ -40,12 +40,12 @@ pc - No pet currently but once "mom came home with it".
 
 - Archive _Done_ tasks :tada:
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - organizing-private#4 -  transfer wise
-    - #156 - continuing
-    - #154 - continuing
-    - #136 - Bios collected, visual treatment.
-    - #102 - AGM
-    - #177 
+    - [private#4](https://github.com/hyphacoop/organizing-private/issues/4) -  transfer wise
+    - [#156](https://github.com/hyphacoop/organizing/issues/156) - continuing
+    - [#154](https://github.com/hyphacoop/organizing/issues/154) - continuing
+    - [#136](https://github.com/hyphacoop/organizing/issues/136) - Bios collected, visual treatment.
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) - AGM
+    - [#177](https://github.com/hyphacoop/organizing/issues/177) 
 - Triage new tasks
     - Personal Hypha E-Mail
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]

--- a/_posts/meeting-notes/2019-11-13-all-hands-meeting.md
+++ b/_posts/meeting-notes/2019-11-13-all-hands-meeting.md
@@ -34,26 +34,26 @@ Notetaker:  yurko :raising_hand: Next up: gi, uv, pc, dc, el, bl, yj
 ### Task Board Review
 
 - Archive _Done_ tasks :tada:
-    - #134 not done
-    - #117 closed. #todo add notes
-    - #137 deferred
-    - #85 complete
-    - #92 @dcwalk just need to move it forward
-    - #119 #todo next bizdev
-    - #132 on-stack to discuss today
-    - #71 patcon is blocking humself
-    - #135 patcon and elon will talk #todo
-    - #127 #todo documentation. #discussion: is this working? yay/nay
-    - #95 felt bocked. up to ben (assignee)
+    - [#134](https://github.com/hyphacoop/organizing/issues/134) not done
+    - [#117](https://github.com/hyphacoop/organizing/issues/117) closed. #todo add notes
+    - [#137](https://github.com/hyphacoop/organizing/issues/137) deferred
+    - [#85](https://github.com/hyphacoop/organizing/issues/85) complete
+    - [#92](https://github.com/hyphacoop/organizing/issues/92) @dcwalk just need to move it forward
+    - [#119](https://github.com/hyphacoop/organizing/issues/119) #todo next bizdev
+    - [#132](https://github.com/hyphacoop/organizing/issues/132) on-stack to discuss today
+    - [#71](https://github.com/hyphacoop/organizing/issues/71) patcon is blocking humself
+    - [#135](https://github.com/hyphacoop/organizing/issues/135) patcon and elon will talk #todo
+    - [#127](https://github.com/hyphacoop/organizing/issues/127) #todo documentation. #discussion: is this working? yay/nay
+    - [#95](https://github.com/hyphacoop/organizing/issues/95) felt bocked. up to ben (assignee)
         - dcwalk: maybe start with doc before PR? bl: :+1:
     - #discussion what's our line of adding things to todos? (patcon)
-    - #130 money moved. waiting on bank work. so CLOSING :tada: 
+    - [#130](https://github.com/hyphacoop/organizing/issues/130) money moved. waiting on bank work. so CLOSING :tada: 
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - #137 downgraded priority
+    - [#137](https://github.com/hyphacoop/organizing/issues/137) downgraded priority
 - Triage new tasks
-    - #143 no label. just new ticket. need to send contract.
-    - #120 one-pager for our internal understanding. #new isuse: HST and non-profit vs for-profit.
-    - #118
+    - [#143](https://github.com/hyphacoop/organizing/issues/143) no label. just new ticket. need to send contract.
+    - [#120](https://github.com/hyphacoop/organizing/issues/120) one-pager for our internal understanding. #new isuse: HST and non-profit vs for-profit.
+    - [#118](https://github.com/hyphacoop/organizing/issues/118)
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 - #todo dc: spawn issue for explainer/documentation of our status as a nonprofit worker co-operative
 

--- a/_posts/meeting-notes/2019-11-27-all-hands-meeting.md
+++ b/_posts/meeting-notes/2019-11-27-all-hands-meeting.md
@@ -33,28 +33,28 @@ Notetaker:  pc :raising_hand: Next up: gi, dc, el, bl, yj, uv, pc
 ### Task Board Review
 
 - Archive _Done_ tasks :tada:
-    - #134 credit card
+    - [#134](https://github.com/hyphacoop/organizing/issues/134) credit card
         - dc and yj to sort
-    - #86 time tracking
+    - [#86](https://github.com/hyphacoop/organizing/issues/86) time tracking
         - #discuss time-tracking categories (ben)
         - udit recommitting to closing
         - yj: ill get my hours done by next meeting
         - el: I have been using it
-    - #85 complete biz plan
+    - [#85](https://github.com/hyphacoop/organizing/issues/85) complete biz plan
         - :house: COTTAGE. no computer. dc on it.
-    - #92 publish handbook. done!
-    - #119 set up CRM. still open
-    - #143 virtual goups workshop. dc needs to push.
-    - #132 comms tools. ben feels blocked. 2 votes.
+    - [#92](https://github.com/hyphacoop/organizing/issues/92) publish handbook. done!
+    - [#119](https://github.com/hyphacoop/organizing/issues/119) set up CRM. still open
+    - [#143](https://github.com/hyphacoop/organizing/issues/143) virtual goups workshop. dc needs to push.
+    - [#132](https://github.com/hyphacoop/organizing/issues/132) comms tools. ben feels blocked. 2 votes.
         - #discussion to unblock
-    - #135 upgrade loomio.
+    - [#135](https://github.com/hyphacoop/organizing/issues/135) upgrade loomio.
         - all checked. patcon passing on last comment. elon closed! :tada: 
-    - #127 jitsi meet pilot. #discussion
-    - #145 labels. ready for review from dc. almost done.
-    - #131 email policy. was demo of pc's proposal. feedback from el and yj. demo'ing revised proposal next infra WG. will bring to all-hands if good.
-    - #154 yj: in-process. still need to do payroll. going well
+    - [#127](https://github.com/hyphacoop/organizing/issues/127) jitsi meet pilot. #discussion
+    - [#145](https://github.com/hyphacoop/organizing/issues/145) labels. ready for review from dc. almost done.
+    - [#131](https://github.com/hyphacoop/organizing/issues/131) email policy. was demo of pc's proposal. feedback from el and yj. demo'ing revised proposal next infra WG. will bring to all-hands if good.
+    - [#154](https://github.com/hyphacoop/organizing/issues/154) yj: in-process. still need to do payroll. going well
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - #132 comms. as-is for now.
+    - [#132](https://github.com/hyphacoop/organizing/issues/132) comms. as-is for now.
     - no other thoughts raised
 - Triage new tasks
     - skip for the week.

--- a/_posts/meeting-notes/2019-12-03-finance-wg-meeting.md
+++ b/_posts/meeting-notes/2019-12-03-finance-wg-meeting.md
@@ -13,11 +13,11 @@ Notetaker:  yj
 - Logistic things (ben)
     - Delegate person for All Hands to give summary
     - Meeting time
-- TransferWise business account walkthrough #154 (ben)
-- QB invoicing in USD #154 (ben)
-- Payroll #156
-- Shareholder loans #154
-- Bookkeeper meeting #122
+- TransferWise business account walkthrough [#154](https://github.com/hyphacoop/organizing/issues/154) (ben)
+- QB invoicing in USD [#154](https://github.com/hyphacoop/organizing/issues/154) (ben)
+- Payroll [#156](https://github.com/hyphacoop/organizing/issues/156)
+- Shareholder loans [#154](https://github.com/hyphacoop/organizing/issues/154)
+- Bookkeeper meeting [#122](https://github.com/hyphacoop/organizing/issues/122)
 
 ## Notes
 
@@ -25,9 +25,9 @@ _`#ask` indicates questions for our accountant or bookkeeper_
 
 - pc to be All Hands presenter
 - backlog grooming
-    - #120 low priority
-    - added #160 to backlog
-    - #121 low priority
+    - [#120](https://github.com/hyphacoop/organizing/issues/120) low priority
+    - added [#160](https://github.com/hyphacoop/organizing/issues/160) to backlog
+    - [#121](https://github.com/hyphacoop/organizing/issues/121) low priority
 - re: meeting time.
     - same time. value yurko's attention more than ben's sleep. new hold in calendar for 1h before #todo:patcon
 
@@ -54,10 +54,10 @@ _`#ask` indicates questions for our accountant or bookkeeper_
         - bl: would prefer to keep it more restrictive
         - Share l/p with 1 other rest view
         - pc will get access
-- #154 USD invoices
+- [#154](https://github.com/hyphacoop/organizing/issues/154) USD invoices
     - yj: can't expect client to always have transferwise
     - #ask bookkeeper do we need to track transferwise movements between currencies in our books?
-        - #todo:patcon transfer to #122
+        - #todo:patcon transfer to [#122](https://github.com/hyphacoop/organizing/issues/122)
     - bl: may need to track USD in our books
     - yj: when I spend CAD credit card in US, it just converts. how is this different?
     - bl: proposal = we should try with accepting USD, and if it's hard, revise our policy to be CAD only.
@@ -71,7 +71,7 @@ _`#ask` indicates questions for our accountant or bookkeeper_
     - pc: if no one else convinced by new research, will retract concern.
     - after ben left call, yj spoke about finding more resources recommending biweekly for hourly or irregular work.
     - #ask how complex is it to switch pay periods
-        - #todo:patcon transfer to #122
+        - #todo:patcon transfer to [#122](https://github.com/hyphacoop/organizing/issues/122)
         
 ### Action Items for Cultivator
 

--- a/_posts/meeting-notes/2019-12-11-all-hands-meeting.md
+++ b/_posts/meeting-notes/2019-12-11-all-hands-meeting.md
@@ -43,16 +43,16 @@ Notetaker:  el :raising_hand: Next up: el, dc, bl, yj, uv, pc, gi
 
 - Archive _Done_ tasks :tada:
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - #15 need to discuse with the group
-    - #119 patcon: still needs pipeline that matches our actual thing. +1 ben for tomorrow looking
-    - #154
-    - #156 update below
-    - #134 ongoing
-    - #143 dc need to return the contract
-    - #131 set up WG call for planning
-    - #86 Done
-    - #127 el: review and close
-    - #145 pc thinks its done now
+    - [#15](https://github.com/hyphacoop/organizing/issues/15) need to discuse with the group
+    - [#119](https://github.com/hyphacoop/organizing/issues/119) patcon: still needs pipeline that matches our actual thing. +1 ben for tomorrow looking
+    - [#154](https://github.com/hyphacoop/organizing/issues/154)
+    - [#156](https://github.com/hyphacoop/organizing/issues/156) update below
+    - [#134](https://github.com/hyphacoop/organizing/issues/134) ongoing
+    - [#143](https://github.com/hyphacoop/organizing/issues/143) dc need to return the contract
+    - [#131](https://github.com/hyphacoop/organizing/issues/131) set up WG call for planning
+    - [#86](https://github.com/hyphacoop/organizing/issues/86) Done
+    - [#127](https://github.com/hyphacoop/organizing/issues/127) el: review and close
+    - [#145](https://github.com/hyphacoop/organizing/issues/145) pc thinks its done now
 - Triage new tasks
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 
@@ -62,7 +62,7 @@ Notetaker:  el :raising_hand: Next up: el, dc, bl, yj, uv, pc, gi
     - Meeting tomorrow for 2 hours in call
     - pc and bl put some leads into CRM, have a look before meeting if you get a chance
 - [Finance][fin-wg] :white_check_mark: [`wg:finance`][l-fin]
-    - patcon: #156 Payroll. Finance WG decided to go with Wagepoint. Registered. CRA payroll program account is now set up. Currently doing Wagepoint setup.
+    - patcon: [#156](https://github.com/hyphacoop/organizing/issues/156) Payroll. Finance WG decided to go with Wagepoint. Registered. CRA payroll program account is now set up. Currently doing Wagepoint setup.
     - Decided not to go with QB payroll and using wagepoint
     - Decide on vacation time 
     - e.g. $100 from client, employee gets $75 + (4% of $75)

--- a/_posts/meeting-notes/2019-12-12-business-planning.md
+++ b/_posts/meeting-notes/2019-12-12-business-planning.md
@@ -17,7 +17,7 @@ Notetaker:  ben, patcon
 - approval of business plan
 - review of task board
 - discussion
-    - #136 hypha intro dec (udit)
+    - [#136](https://github.com/hyphacoop/organizing/issues/136) hypha intro dec (udit)
     - CRM pipeline (ben, patcon)
 
 ## Notes
@@ -26,7 +26,7 @@ Notetaker:  ben, patcon
 :heart: Feeling  
 :bulb: Ideas/Proposals
 
-- #85 business plan
+- [#85](https://github.com/hyphacoop/organizing/issues/85) business plan
     - dc: let's treat this as snapshotted doc that goes to sleep, not living doc :+1:
         - :bulb: let's put away and revisit for AGM? :+1: all
     - pc: On social assistance rn: Ontario Works. part of that is to write and review a business plan with Toronto Business Development Centre.
@@ -34,18 +34,18 @@ Notetaker:  ben, patcon
         - will keep comments for later incorp during next round
         - uv: #todo make snapshot before comments
     - bl: this is intenal doc, right? all: yes.
-- #136 Intro deck: https://github.com/hyphacoop/organizing/issues/136
+- [#136](https://github.com/hyphacoop/organizing/issues/136) Intro deck: https://github.com/hyphacoop/organizing/issues/136
     - uv: project ppl pls put a paragraph (Primal Glow, Aether) #todo:bl+pc
     - uv: what other capabilities to put in a client-facing deck
     - uv: schedule half hour to do some brainstorming. #todo:uv schedule in new year.
-    - bl: overlap with website and garry's work #77 
+    - bl: overlap with website and garry's work [#77](https://github.com/hyphacoop/organizing/issues/77) 
     - uv: timeline, done by end of Jan
     - all: focus on prior experiences and skillsets
     - dc: suggestion: template, ways to add future projects/elements to it
         - bl: maybe include sufficient details in internal project proposal template
             - uv: yes, though audience a little different
     - dc: go back to CWCF proposal and get those prior experiences in the deck since we alrdy have permission to share #action
-- #119 CRM and client pipeline
+- [#119](https://github.com/hyphacoop/organizing/issues/119) CRM and client pipeline
     - what are our pipelines?
     - bl: :heart: current columns don't work for me
     - uv+bl: :bulb: let's make one default one that suits us

--- a/_posts/meeting-notes/2019-12-17-finance-wg-meeting.md
+++ b/_posts/meeting-notes/2019-12-17-finance-wg-meeting.md
@@ -24,26 +24,26 @@ _`#acc` indicates questions for our accountant_
 ### Task Board Review
 
 - Archive _Done_ tasks :tada:
-    - #130 Migration to Dejardins
-    - #111 CRA my business
-    - #89 Draft accounting billing payroll workflow. Closed orphan todos.
-    - #65 Setup bank account
+    - [#130](https://github.com/hyphacoop/organizing/issues/130) Migration to Dejardins
+    - [#111](https://github.com/hyphacoop/organizing/issues/111) CRA my business
+    - [#89](https://github.com/hyphacoop/organizing/issues/89) Draft accounting billing payroll workflow. Closed orphan todos.
+    - [#65](https://github.com/hyphacoop/organizing/issues/65) Setup bank account
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - organizing-private#4 Setup TransferWise
+    - [private#4](https://github.com/hyphacoop/organizing-private/issues/4) Setup TransferWise
         - bl - Hope to finish by End Of Month. 
         - bl - remaining: sorting out "beneficiary address", and documenting
-    - #156 Run first payroll
+    - [#156](https://github.com/hyphacoop/organizing/issues/156) Run first payroll
         - pc: Talked to sales agent
             - spoke with onboarding agent (more helpful)
             - got 40 min walkthough
-    - #154 Setup Quickbooks
+    - [#154](https://github.com/hyphacoop/organizing/issues/154) Setup Quickbooks
         - Discussion: invoice footers. shortlinks to CRA docs. keep them?
             - bl: shortlinks kinda long
             - will have to keep them around indefinitely
             - Suggestion: use article numbers instead of shortlink on invoice for internal refrences
             - #todo:patcon include article numbers to CRA legilations in footer
         - re-assign to just yurko? :+1:
-    - #122 Bookkeeping. nothing.
+    - [#122](https://github.com/hyphacoop/organizing/issues/122) Bookkeeping. nothing.
 - Triage new tasks
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 
@@ -85,10 +85,10 @@ _`#acc` indicates questions for our accountant_
         - We can enter Stat pay and custom amount for wage
             - Check # of hours 177.33??
     - NAICS code? [link](https://www23.statcan.gc.ca/imdb/p3VD.pl?Function=getVD&TVD=1181553&CVD=1182718&CPV=541514&CST=01012017&CLV=5&MLV=5) (via dc)
-- #todo infra passbolt admin. created #175
+- #todo infra passbolt admin. created [#175](https://github.com/hyphacoop/organizing/issues/175)
     - #todo infra doc groups
     - #todo safe place to store within the week
-- #todo wrap up in year-end summary #164
+- #todo wrap up in year-end summary [#164](https://github.com/hyphacoop/organizing/issues/164)
     - #todo couple lines from each 1h before
     - #todo:patcon group summary
 

--- a/_posts/meeting-notes/2020-01-08-all-hands-meeting.md
+++ b/_posts/meeting-notes/2020-01-08-all-hands-meeting.md
@@ -42,13 +42,13 @@ Notetaker:  bl :raising_hand: Next up: bl, yj, uv, pc, gi, el, dc
 - Triage new tasks
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 
-- #156 call bookkeeper, check if books look okay, talk to payroll person if we're doing things correctly
+- [#156](https://github.com/hyphacoop/organizing/issues/156) call bookkeeper, check if books look okay, talk to payroll person if we're doing things correctly
     - bl: comfortable moving forward without consulting bookkeeper, but fine if you'd like to consult
     - pc: should be wrapped by friday
-- organizing-private#4 bl just needs to finish documenting
+- [private#4](https://github.com/hyphacoop/organizing-private/issues/4) bl just needs to finish documenting
     - pc: do retrospective
-- #122 drop questions for bookkeeper
-- #119 crm. closing out and will review and re-ticket outstanding
+- [#122](https://github.com/hyphacoop/organizing/issues/122) drop questions for bookkeeper
+- [#119](https://github.com/hyphacoop/organizing/issues/119) crm. closing out and will review and re-ticket outstanding
 
 - some confusion about triaging step, doesn't look like we have any organizing tickets there, skipping
 

--- a/_posts/meeting-notes/2020-01-08-governance-wg-meeting.md
+++ b/_posts/meeting-notes/2020-01-08-governance-wg-meeting.md
@@ -113,9 +113,9 @@ From 2019-12-18 all hands:
 
 ### Parked discussions
 
-- #140 Improve org-wide task flow
+- [#140](https://github.com/hyphacoop/organizing/issues/140) Improve org-wide task flow
 - What do we want to get out of these meetings?
-- #102 Roadmapping to the AGM
+- [#102](https://github.com/hyphacoop/organizing/issues/102) Roadmapping to the AGM
 - Scope of Working Group
 - Peer-reviewing
  

--- a/_posts/meeting-notes/2020-01-09-business-planning.md
+++ b/_posts/meeting-notes/2020-01-09-business-planning.md
@@ -70,13 +70,13 @@ Notetaker:  dc
     - dc: flipped model where garry is a SME "Subject Matter Expert", and have someone as a project manager
     - uv: happy to lead lead
 - Timeline on first priority:
-    - **Feb 7** Develop pitch deck #136 
+    - **Feb 7** Develop pitch deck [#136](https://github.com/hyphacoop/organizing/issues/136) 
         - **mid-Jan** First-pass
         - **end-Jan** Feedback period closes
-    - **Feb-Mar** Branding exercise phase #77
+    - **Feb-Mar** Branding exercise phase [#77](https://github.com/hyphacoop/organizing/issues/77)
         - Branding look book (guidelines) 
-        - Letterhead #100
-    - **mid-Mar** Initial website -- maybe skeleton/onepager with "wordmark", not full treatment/implementation #80
+        - Letterhead [#100](https://github.com/hyphacoop/organizing/issues/100)
+    - **mid-Mar** Initial website -- maybe skeleton/onepager with "wordmark", not full treatment/implementation [#80](https://github.com/hyphacoop/organizing/issues/80)
     - **??TBD??** Final "re-launched" website
 
 ### Sales Opportunities
@@ -100,7 +100,7 @@ Notetaker:  dc
 - #todo dc to update calendar for next few months
 
 ### Todos
-- [ ] uv: draft pitch deck for comment by **Wed** -- task exists in #136
+- [ ] uv: draft pitch deck for comment by **Wed** -- task exists in [#136](https://github.com/hyphacoop/organizing/issues/136)
 - [x] bl: draft dweb meshnet proposal for all-hands seek member buy-in -- THERE IS!
 - [x] dc: post in chat about interest around website hosting/maintenance opportunity
 - [x] dc: update patcon about start.coop

--- a/_posts/meeting-notes/2020-01-14-finance-wg.md
+++ b/_posts/meeting-notes/2020-01-14-finance-wg.md
@@ -34,11 +34,11 @@ Notetaker:  pc
 
 - Archive _Done_ tasks :tada:
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - #156 payroll. done. will discuss
-    - private#4 transferwise. done. can check off in discussion.
-    - #154 quickbooks setup. no progress. patcon needs to move it fwd.
+    - [#156](https://github.com/hyphacoop/organizing/issues/156) payroll. done. will discuss
+    - [private#4](https://github.com/hyphacoop/organizing-private/issues/4) transferwise. done. can check off in discussion.
+    - [#154](https://github.com/hyphacoop/organizing/issues/154) quickbooks setup. no progress. patcon needs to move it fwd.
     - #... bookkeeper. assigned to patcon, as he's become touchpoint. will update in discussion.
-    - #134 credit card. no progress. yj: there a block? no.
+    - [#134](https://github.com/hyphacoop/organizing/issues/134) credit card. no progress. yj: there a block? no.
         - pc: might
 - Triage new tasks
     - #todo create task for expense reimbursement process

--- a/_posts/meeting-notes/2020-01-15-governance-wg-meeting.md
+++ b/_posts/meeting-notes/2020-01-15-governance-wg-meeting.md
@@ -54,7 +54,7 @@ Notetaker: dc
         - pc: add to triage
     - pc: do we need a new template?
         - dc: happy to work off general
-- #140 Improve org-wide task flow
+- [#140](https://github.com/hyphacoop/organizing/issues/140) Improve org-wide task flow
     - dc, pc: reviewed issue but don't feel it is a priority right now to approach in this way
     - we'll grow into it
 - Milestones into Objectives (Co-work below)
@@ -63,7 +63,7 @@ Notetaker: dc
         - #todo ask any reason these might be sensitive info
         - #todo check about adding in with Biz Dev
         - Handbook
-- #102 Roadmapping to the AGM (Co-work below)
+- [#102](https://github.com/hyphacoop/organizing/issues/102) Roadmapping to the AGM (Co-work below)
     - Initial conversation about structure and dates
     - #todo Develop plan of work to achieve milestones (with AGM as critical milestone)
 

--- a/_posts/meeting-notes/2020-01-28-finance-wg.md
+++ b/_posts/meeting-notes/2020-01-28-finance-wg.md
@@ -33,8 +33,8 @@ Notetaker:  bl
 - Archive _Done_ tasks :tada:
     - 2 archived
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - private#4 need yj pc review
-    - #156 payroll (see discussion)
+    - [private#4](https://github.com/hyphacoop/organizing-private/issues/4) need yj pc review
+    - [#156](https://github.com/hyphacoop/organizing/issues/156) payroll (see discussion)
 - Triage new tasks
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 

--- a/_posts/meeting-notes/2020-01-29-governance-wg-meeting.md
+++ b/_posts/meeting-notes/2020-01-29-governance-wg-meeting.md
@@ -55,7 +55,7 @@ Notetaker: dc, pc
         - #90 service inventory
             - good #cowork task
         - #cowork create social media role description #todo
-        - #81 private archive mostly done #cowork last bit
+        - private#81 archive mostly done #cowork last bit
     - [`wg:ops`][l-ops] label review
     - Triage new tasks
     - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]

--- a/_posts/meeting-notes/2020-01-29-governance-wg-meeting.md
+++ b/_posts/meeting-notes/2020-01-29-governance-wg-meeting.md
@@ -37,25 +37,25 @@ Notetaker: dc, pc
     - Archive _Done_ tasks :tada:
         - done.
     - Review [HIGH `[priority-★★★]`][l-pri-hi]
-        - #155 dc did first pass. reviewed some gov and OCA docs.
-        - #101 bylaws
+        - [#155](https://github.com/hyphacoop/organizing/issues/155) dc did first pass. reviewed some gov and OCA docs.
+        - [#101](https://github.com/hyphacoop/organizing/issues/101) bylaws
             - what's in scope of bylaws?
             - dc: story of student union: template bylaws and added extra. operating book had bylaw-y comments. split was all off.
             - dc: plain language
             - pc: would love to read "bad bylaws" to develop stronger sense
             - dc: good chapters in "ours to hack and own" platform coop book
-        - #125 WSIB
+        - [#125](https://github.com/hyphacoop/organizing/issues/125) WSIB
             - dc: can get tender letter on file. some clients might want
             - WSIB not same as meeting OSHA (and this is operations)
             - dc: WSIB primarily protects employers (cynical take). employees can still file for claims if we don't pay in
             - dc: we should think of this as an "employer protection" task, not "employee protection"
             - DECISION: fill out online form to get on WSIB radar #todo
-        - #97 time-tracking role
+        - [#97](https://github.com/hyphacoop/organizing/issues/97) time-tracking role
             - good #cowork task
-        - #90 service inventory
+        - [#90](https://github.com/hyphacoop/organizing/issues/90) service inventory
             - good #cowork task
         - #cowork create social media role description #todo
-        - private#81 archive mostly done #cowork last bit
+        - [private#81](https://github.com/hyphacoop/organizing-private/issues/81) archive mostly done #cowork last bit
     - [`wg:ops`][l-ops] label review
     - Triage new tasks
     - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
@@ -63,14 +63,14 @@ Notetaker: dc, pc
 
 ### Discussions
 
-- #102 AGM [Dates](https://loomio.hypha.coop/p/KaUbQxIS/when-are-you-available-for-our-first-agm-) 
+- [#102](https://github.com/hyphacoop/organizing/issues/102) AGM [Dates](https://loomio.hypha.coop/p/KaUbQxIS/when-are-you-available-for-our-first-agm-) 
     - dc: surprised ppl thought this was too far in advance to sched
         - :+1: patcon should be high priority. dc: esp first one
     - dc: consider sched board of director meeting as section of AGM
         - Interpretation that ALL board _must_ be there
 - AGM [visioning responses](https://github.com/hyphacoop/organizing/issues/102#issuecomment-574895106) and goal-setting
     - Reviewed and discussed in [AGM Plannning Doc](https://docs.google.com/document/d/1fBm-OB_haaGEIEDGvekMA9wivjJNiA1MCP1Qf-i6QbA/edit#heading=h.815plvwj00v9)
-- #102 Milestones into Objectives (Co-work below)
+- [#102](https://github.com/hyphacoop/organizing/issues/102) Milestones into Objectives (Co-work below)
     - Review objectives and prepare **"milestones that need to be hit/indicators that demonstrate success"**.
 
 #### Parked discussions
@@ -80,10 +80,10 @@ Notetaker: dc, pc
 
 #### Candidates for co-work
 
-- #97 Time tracker role (social media role?)
-- #90 Add why's to Service Inventory 
-- #81 README work
-- #123 WSIB registration
+- [#97](https://github.com/hyphacoop/organizing/issues/97) Time tracker role (social media role?)
+- [#90](https://github.com/hyphacoop/organizing/issues/90) Add why's to Service Inventory 
+- [#81](https://github.com/hyphacoop/organizing/issues/81) README work
+- [#123](https://github.com/hyphacoop/organizing/issues/123) WSIB registration
 
 ### Co-work: Working Group Milestones into Objectives and Road to AGM 
 

--- a/_posts/meeting-notes/2020-02-12-governance-wg-meeting.md
+++ b/_posts/meeting-notes/2020-02-12-governance-wg-meeting.md
@@ -40,14 +40,14 @@ Notetaker: dc
     - [`wg:ops`][l-ops] label review
     - Triage new tasks
     - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
-- #123 ops. sent email. website not enough for registration.
+- [#123](https://github.com/hyphacoop/organizing/issues/123) ops. sent email. website not enough for registration.
 
 ### Discussions
 
-- #102 AGM status update
+- [#102](https://github.com/hyphacoop/organizing/issues/102) AGM status update
     - discussing [doc](https://docs.google.com/document/d/1fBm-OB_haaGEIEDGvekMA9wivjJNiA1MCP1Qf-i6QbA/edit)
         - need to email everyone individually, not group
-- #202 Peer-feedback
+- [#202](https://github.com/hyphacoop/organizing/issues/202) Peer-feedback
     - happening at agm or launching at agm
     - kickoff too structured? versus accountability on our own time
     - pc: previous experience:
@@ -88,7 +88,7 @@ Notetaker: dc
         - finalizing for AGM meeting
     - #todo patcon to spawn issue with this, also keen to lead on :point_up: 
 - Organization roles
-    - #121 finance
+    - [#121](https://github.com/hyphacoop/organizing/issues/121) finance
         - all just doing stuff, most
         - OKR goal to write guides
             - dc: guides good! but not the same as role (which could just be bullet points)
@@ -99,16 +99,16 @@ Notetaker: dc
         - #todo dc to review
         - #todo ask for opinions/mention at call tonight. discuss next all hands?
     - handbook#13 doc'ing (parked)
-    - #97 time-tracking (parked)
-    - #73 internal PM (parked)
-- #101 By-law planning (parked)
+    - [#97](https://github.com/hyphacoop/organizing/issues/97) time-tracking (parked)
+    - [#73](https://github.com/hyphacoop/organizing/issues/73) internal PM (parked)
+- [#101](https://github.com/hyphacoop/organizing/issues/101) By-law planning (parked)
 
 #### Candidates for co-work
 
-- #97 Time tracker role (social media role?)
-- #90 Add why's to Service Inventory 
-- #81 README work
-- ~~#123 WSIB registration~~ (dc did async)
+- [#97](https://github.com/hyphacoop/organizing/issues/97) Time tracker role (social media role?)
+- [#90](https://github.com/hyphacoop/organizing/issues/90) Add why's to Service Inventory 
+- [#81](https://github.com/hyphacoop/organizing/issues/81) README work
+- ~~[#123](https://github.com/hyphacoop/organizing/issues/123) WSIB registration~~ (dc did async)
 
 ### Process Checkout
 

--- a/_posts/meeting-notes/2020-02-12-standup-meeting.md
+++ b/_posts/meeting-notes/2020-02-12-standup-meeting.md
@@ -115,7 +115,7 @@ pc: move OKRs to spreadsheet?
 - [ ] ben: clean up or migrate OKRs to proper public sheet
 - [ ] pc: handbook PR with process, Os, link to spreadsheet
 - [ ] pc: spawn issue to discuss OKR process and/or role [ops]. "Shall we start with defining tasks/process before defining role?"
-- [ ] ??: CLOSE THE ISSUE #173
+- [ ] ??: CLOSE THE ISSUE [#173](https://github.com/hyphacoop/organizing/issues/173)
 
 <!-- Links: Important -->
 [standup-template]: https://link.hypha.coop/standup-template

--- a/_posts/meeting-notes/2020-02-19-all-hands-meeting.md
+++ b/_posts/meeting-notes/2020-02-19-all-hands-meeting.md
@@ -42,7 +42,7 @@ Notetaker:  uv :raising_hand: Next up: gi, bl, pc, dc, yj, el, uv
     - pc: no high priority tasks in the backlog
 - Triage new tasks
     - no new tasks
-    - dc: request a review of #46
+    - dc: request a review of [#46](https://github.com/hyphacoop/organizing/issues/46)
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 
 ### Working Group Updates

--- a/_posts/meeting-notes/2020-02-20-finance-meeting.md
+++ b/_posts/meeting-notes/2020-02-20-finance-meeting.md
@@ -37,12 +37,12 @@ Notetaker:  yj
 - missing labels [`wg:NULL`][l-none] | [`[priority-NULL]`][l-pri-none]
 
 - Wrap-up and transfer of most of pc's tasks since he is stepping back from wg
-- #156 add decision of stat and payment into handbook, get SINs (updated in issue)
-- #154 closed
-- #122 contract with book keeper? Authority of point person? Assigned to bl
-- #134 will not get CC, wait until corp card is available at 1 year. lowered priority
-- #120 unlbocked and lowered priority until HST is an issue
-- #185 increased priority, look into process
+- [#156](https://github.com/hyphacoop/organizing/issues/156) add decision of stat and payment into handbook, get SINs (updated in issue)
+- [#154](https://github.com/hyphacoop/organizing/issues/154) closed
+- [#122](https://github.com/hyphacoop/organizing/issues/122) contract with book keeper? Authority of point person? Assigned to bl
+- [#134](https://github.com/hyphacoop/organizing/issues/134) will not get CC, wait until corp card is available at 1 year. lowered priority
+- [#120](https://github.com/hyphacoop/organizing/issues/120) unlbocked and lowered priority until HST is an issue
+- [#185](https://github.com/hyphacoop/organizing/issues/185) increased priority, look into process
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-03-04-all-hands-meeting.md
+++ b/_posts/meeting-notes/2020-03-04-all-hands-meeting.md
@@ -49,21 +49,21 @@ Tell one positive and/or negative mood you are feeling and explain why. It can b
 
 - Archive _Done_ tasks :tada:
     - ...
-    - OKR one. pc: is someone leading? bl: #todo (see #199)
-    - #154 quickbooks
+    - OKR one. pc: is someone leading? bl: #todo (see [#199](https://github.com/hyphacoop/organizing/issues/199))
+    - [#154](https://github.com/hyphacoop/organizing/issues/154) quickbooks
 - Review [HIGH `[priority-★★★]`][l-pri-hi]
-    - private#20 QM.
-    - private#18 Free.
+    - [private#20](https://github.com/hyphacoop/organizing-private/issues/20) QM.
+    - [private#18](https://github.com/hyphacoop/organizing-private/issues/18) Free.
         - had call. more one-off than. ladder maybe needed. convos needed: WSIB, insurance. Do we want to do this sort of thing?
         - discussion will continue in Infra WG meeting
         - uv: flagging that if seems complex, client might lose interest. +1 pc
         - yj: i often am relaxed on meeting these sorts of requirements
             - pc bl: wouldn't block.
-    - #156 payroll. one final thing to check off.
-    - #212 domains. no block on expiring.
-    - #199 OKR steward. no progress.
-    - #102 AGM. no progress.
-    - #77 brand identity. ongoing.
+    - [#156](https://github.com/hyphacoop/organizing/issues/156) payroll. one final thing to check off.
+    - [#212](https://github.com/hyphacoop/organizing/issues/212) domains. no block on expiring.
+    - [#199](https://github.com/hyphacoop/organizing/issues/199) OKR steward. no progress.
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) AGM. no progress.
+    - [#77](https://github.com/hyphacoop/organizing/issues/77) brand identity. ongoing.
         - uv: color scheme. wordmark. some idea of visual imagery. initial brand identity = done.
         - created new task for swap out color, font, image. also export square logo [`organizing#219`](https://github.com/hyphacoop/organizing/issues/219)
 - Triage new tasks

--- a/_posts/meeting-notes/2020-03-11-governance-wg-meeting.md
+++ b/_posts/meeting-notes/2020-03-11-governance-wg-meeting.md
@@ -95,17 +95,17 @@ Notetaker:  bl
     - #decision dc: proposes to get reclassified and pay for it (est. $200-400 in first year)
     - "once you get ladders you're in a required industry"
     - #todo bl: communicate to members that this does not block current project proposals
-- #101 By-law planning
+- [#101](https://github.com/hyphacoop/organizing/issues/101) By-law planning
     - dc: start at template and modify, look at resource from other co-ops
     - #todo bl: skim bylaw examples in google drive, read AGM planning doc
     - #todo dc: prep working [meeting] doc for next meeting
-- #102 AGM status update
+- [#102](https://github.com/hyphacoop/organizing/issues/102) AGM status update
     - Quick summary of planning: https://docs.google.com/document/d/1fBm-OB_haaGEIEDGvekMA9wivjJNiA1MCP1Qf-i6QbA/edit?ouid=114071245511075726689&usp=docs_home&ths=true
         - **April 15** initial email out
         - **May** package with schedule
-    - #todo dc: #14 "Good member" desc. for AGM!!!! add to sched.
+    - #todo dc: [#14](https://github.com/hyphacoop/organizing/issues/14) "Good member" desc. for AGM!!!! add to sched.
         - bl: possibly co-write some of that based on draft after discussing first year frictions
-    - #todo dc: #104 Amending articles -- make clear in planning doc
+    - #todo dc: [#104](https://github.com/hyphacoop/organizing/issues/104) Amending articles -- make clear in planning doc
     - #toho bl: `agm` label on gh? dc: sure, if helpful
 - WG description for Ops
     - #todo draft an Ops WG description
@@ -127,16 +127,16 @@ Notetaker:  bl
 - Organization roles (parked)
     - From last meeting:
         - [ ] ops could make a template/set of questions for a role to fill
-    - #121 finance
+    - [#121](https://github.com/hyphacoop/organizing/issues/121) finance
     - handbook#13 doc'ing
-    - #97 time-tracking
-    - #73 internal PM 
-    - #198 social media (landed)
+    - [#97](https://github.com/hyphacoop/organizing/issues/97) time-tracking
+    - [#73](https://github.com/hyphacoop/organizing/issues/73) internal PM 
+    - [#198](https://github.com/hyphacoop/organizing/issues/198) social media (landed)
 
 #### Co-work
 
 Candidates:
-- #90 Add why's to Service Inventory 
+- [#90](https://github.com/hyphacoop/organizing/issues/90) Add why's to Service Inventory 
 
 #### Need to talk abt 
 
@@ -156,8 +156,8 @@ Candidates:
 - [ ] communicate to members that this does not block current project proposals
 - [ ] bl: skim bylaw examples in google drive, read AGM planning doc
 - [ ] dc: prep working [meeting] doc for next meeting
-- [ ] dc: #14 "Good member" desc. for AGM!!!! add to sched.
-- [ ] dc: #104 Amending articles -- make clear in planning doc
+- [ ] dc: [#14](https://github.com/hyphacoop/organizing/issues/14) "Good member" desc. for AGM!!!! add to sched.
+- [ ] dc: [#104](https://github.com/hyphacoop/organizing/issues/104) Amending articles -- make clear in planning doc
 - [ ] bl: change **shortlinks** and **meeting templates** to match github readable name of wgs (but don't change github labels and tags)
 - [x] dc: update handbook with wg descriptions (assigned issue) PR => 
 - [ ] bl: add `agm` label on gh

--- a/_posts/meeting-notes/2020-03-18-all-hands.md
+++ b/_posts/meeting-notes/2020-03-18-all-hands.md
@@ -50,14 +50,14 @@ Notetaker:  pc :raising_hand: dc, yj, el, uv, gi, bl, pc
 - Archive DONE tasks :tada:
 	- labels. glossary.
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #201 #95 IP and employee agreement
+	- [#201](https://github.com/hyphacoop/organizing/issues/201) [#95](https://github.com/hyphacoop/organizing/issues/95) IP and employee agreement
 	- handbook#32 wg overview. bizplanning will go over tomorrow.
 - Triage NEW tasks :new:
-	- private#20 Qm. meeting friday to finalize. still on track. haven't had meeting in 2wks.
-	- private#31 pls review. final notice.
-	- private#18 was left hanging a bit.
+	- [private#20](https://github.com/hyphacoop/organizing-private/issues/20) Qm. meeting friday to finalize. still on track. haven't had meeting in 2wks.
+	- [private#31](https://github.com/hyphacoop/organizing-private/issues/31) pls review. final notice.
+	- [private#18](https://github.com/hyphacoop/organizing-private/issues/18) was left hanging a bit.
 	    - bl: last comms? yj: 2wks. quote "next week". bl: feels long.
-    - #219 branding assets. waiting on +1 from bl+gi
+    - [#219](https://github.com/hyphacoop/organizing/issues/219) branding assets. waiting on +1 from bl+gi
         - bl: banner maybe looks phallic
         - bl: did you change style? pc: screenshotted preview, but no changes saved?
     - #? social media. done.

--- a/_posts/meeting-notes/2020-03-18-governance.md
+++ b/_posts/meeting-notes/2020-03-18-governance.md
@@ -37,7 +37,7 @@ Notetaker:  bl
 	- archived
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- bl: concern over AGM timeline, not being in-person
-	- dc: bring up OKR stewardship process at today's All Hands #199
+	- dc: bring up OKR stewardship process at today's All Hands [#199](https://github.com/hyphacoop/organizing/issues/199)
 	    - #todo archive [2020 Q1/Q2 OKR exercise](https://hackmd.io/fb9JLJioRDqoGdP8DEsMfA?view#Proposed-Metrics) in a new folder in public organizing repo
 	- dc: covid internal vs. external response
 	    - internal
@@ -59,7 +59,7 @@ Notetaker:  bl
                     - help spin up quick static sites connecting ppl
                     - reachout to alan, design justice folks, maggie's, unions, etc.
                     - e.g., mutual aid connecting in Toronto https://spaces.commonknowledge.coop/
-    - dc: covid stuff may make wsib issue higher priority #217
+    - dc: covid stuff may make wsib issue higher priority [#217](https://github.com/hyphacoop/organizing/issues/217)
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-03-25-governance.md
+++ b/_posts/meeting-notes/2020-03-25-governance.md
@@ -43,8 +43,8 @@ Notetaker:  bl
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- checked out "shape"--in good position, all high priority underway/discussed on this call
 - [`wg:gov`][l-gov] label review
-    - #101 Write by-laws, discuss this today
-    - #102 AGM, update notes to reflect agreement on plan: https://github.com/hyphacoop/organizing/pull/241
+    - [#101](https://github.com/hyphacoop/organizing/issues/101) Write by-laws, discuss this today
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) AGM, update notes to reflect agreement on plan: https://github.com/hyphacoop/organizing/pull/241
     - Backlog: all agm or `priority-★☆☆`
     - The feedback piece, does it need more time? A process earlier?
     - bl: want to socialize peer review process and "good member" discussion earlier than close to AGM
@@ -53,7 +53,7 @@ Notetaker:  bl
 - [`wg:ops`][l-ops] label review
     - [quick side chat on social card for twitter on covid19 resource]
     - many to discuss below
-    - #217 health and safety? in relation to covid-19
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) health and safety? in relation to covid-19
         - dc: how we respond to employees who are sick, we should already be compliant with requirements
         - dc: site safety things re: covid-19 (e.g. PPE) don't relate to us bc remote
         - dc: focus on policy response first
@@ -61,14 +61,14 @@ Notetaker:  bl
 ### Discussions
 
 - Ops:
-    - #199 Stewarding OKR process
+    - [#199](https://github.com/hyphacoop/organizing/issues/199) Stewarding OKR process
         - reviewed https://hackmd.io/ImMcCS6hTQWcCStwHK8qRA?view and will be added #todo:dc to handbook
         - #todo:bl announce and discuss at standup tonight
-    - #229 External response to COVID-19 
+    - [#229](https://github.com/hyphacoop/organizing/issues/229) External response to COVID-19 
         - [notes below]
-    - #240 Internal COVID-19 response 
+    - [#240](https://github.com/hyphacoop/organizing/issues/240) Internal COVID-19 response 
 - Governance:
-    - #101 Write by-laws
+    - [#101](https://github.com/hyphacoop/organizing/issues/101) Write by-laws
 
 #### External response to COVID-19 
 
@@ -85,7 +85,7 @@ Notetaker:  bl
         - dc: floating a meeting after call today makes sense
         - dc: there's a flood of resources already, tons of gdocs linking to gdocs
         - bl: what is our value proposition, lots of sharing what folks do, we can try to focus on _doing_ (smaller reach, deeper impact)
-        - bl: to review/closeout #229
+        - bl: to review/closeout [#229](https://github.com/hyphacoop/organizing/issues/229)
 - Initial places to publish:
     - toronto:
         - [x] civic tech 
@@ -130,7 +130,7 @@ Notetaker:  bl
 
 ### Co-work
 
-- #101 write by-laws
+- [#101](https://github.com/hyphacoop/organizing/issues/101) write by-laws
     - dc: plain language, closer to "come as you are" handbook
     - bl: treasurer or no treasurer, defined in bylaw?
         - dc: finance role vs. treasurer, may need for audit

--- a/_posts/meeting-notes/2020-04-08-governance.md
+++ b/_posts/meeting-notes/2020-04-08-governance.md
@@ -37,33 +37,33 @@ Notetaker:  bl
 ### Task Board Review
 
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #199 OKR
-	- #240 will discuss COVID-19 internal response
-	- #102 AGM -- intentionally not worked on
+	- [#199](https://github.com/hyphacoop/organizing/issues/199) OKR
+	- [#240](https://github.com/hyphacoop/organizing/issues/240) will discuss COVID-19 internal response
+	- [#102](https://github.com/hyphacoop/organizing/issues/102) AGM -- intentionally not worked on
 	- dc, bl agree to close the issue for Mozilla proposal, don't require internal proposal
 - [`wg:gov`][l-gov] label review
-    - #101 bylaws not touched, reassigned from bl to dc
+    - [#101](https://github.com/hyphacoop/organizing/issues/101) bylaws not touched, reassigned from bl to dc
     - handbook#13 intentionally blocked
-    - #133 not touched
+    - [#133](https://github.com/hyphacoop/organizing/issues/133) not touched
     - handbook#15 "how to get involved" -- does this become onboarding?
-    - #155 up priority, needs to happen, (related to #120 HST), bl to step in
+    - [#155](https://github.com/hyphacoop/organizing/issues/155) up priority, needs to happen, (related to [#120](https://github.com/hyphacoop/organizing/issues/120) HST), bl to step in
 - [`wg:ops`][l-ops] label review
-    - #95 IP assignment, bl
-    - #250 hiring process -- needs to be fleshed out below
-    - #131 much closer to being done than looks, join infra meeting to resolve?
+    - [#95](https://github.com/hyphacoop/organizing/issues/95) IP assignment, bl
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process -- needs to be fleshed out below
+    - [#131](https://github.com/hyphacoop/organizing/issues/131) much closer to being done than looks, join infra meeting to resolve?
         - infra should take care of _how to implement internal routing and host mailboxes_
         - ops should decide policy on _who and when does a new email address spawn_
         - plan can be "tell infra" for creating email, treat as third-party service provided by el
         - #todo join infra call to sort this
-    - #97 roles attached to working group #73 #97 #121
+    - [#97](https://github.com/hyphacoop/organizing/issues/97) roles attached to working group [#73](https://github.com/hyphacoop/organizing/issues/73) [#97](https://github.com/hyphacoop/organizing/issues/97) [#121](https://github.com/hyphacoop/organizing/issues/121)
         - need guideline on this "this is how we do timetracking"
         - split around payroll side?
         - #todo make the template around role spawn an issue for this
             - update [roles page](https://handbook.hypha.coop/roles.html)
             - make template
             - "empower" WGs/people with process to define their own
-    - #217 dc to pick up, some tasks this week
-    - #175 passbolt
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) dc to pick up, some tasks this week
+    - [#175](https://github.com/hyphacoop/organizing/issues/175) passbolt
         - #todo talk with infra about how to land this
 
 ### OKR Review 
@@ -76,9 +76,9 @@ https://docs.google.com/spreadsheets/d/1hMFS3IhzZOFQA-yjt7lFcoVO0Ry6erFEH7D1Nswv
 
 ### Discussions
 
-- #240 Internal COVID-19 response (todos at bottom of the docs)
+- [#240](https://github.com/hyphacoop/organizing/issues/240) Internal COVID-19 response (todos at bottom of the docs)
     - https://github.com/hyphacoop/organizing-private/issues/35
-- #250 Hiring
+- [#250](https://github.com/hyphacoop/organizing/issues/250) Hiring
     - PM for infra
     - TODOs from implementation doc:
         - [ ] dc: grab descriptions of hiring process, job descriptions from elsewhere
@@ -95,10 +95,10 @@ https://docs.google.com/spreadsheets/d/1hMFS3IhzZOFQA-yjt7lFcoVO0Ry6erFEH7D1Nswv
         - [ ] ip assignment, contractor agreement 
         - [ ] add to handbook: employee bulliten board (OSHA)  
 - Defining roles (park to next week)
-    - #97 #121 #73 all roles atached to WG
+    - [#97](https://github.com/hyphacoop/organizing/issues/97) [#121](https://github.com/hyphacoop/organizing/issues/121) [#73](https://github.com/hyphacoop/organizing/issues/73) all roles atached to WG
     - proof of concept social media
     - PM for infra
-- #todo:bl join infra meeting to discuss #131 and #175, review/update WG description
+- #todo:bl join infra meeting to discuss [#131](https://github.com/hyphacoop/organizing/issues/131) and [#175](https://github.com/hyphacoop/organizing/issues/175), review/update WG description
 
 ### Co-work
 

--- a/_posts/meeting-notes/2020-04-14-infrastructure.md
+++ b/_posts/meeting-notes/2020-04-14-infrastructure.md
@@ -35,13 +35,13 @@ Notetaker:  bl
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- Archived #258
+	- Archived [#258](https://github.com/hyphacoop/organizing/issues/258)
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #246 #todo:el to finish up policy
-	- #238 bl to continue trialing
-	- #244 yj to confirm then close
-	- #253 bl has a comment for el to answer
-	- #168
+	- [#246](https://github.com/hyphacoop/organizing/issues/246) #todo:el to finish up policy
+	- [#238](https://github.com/hyphacoop/organizing/issues/238) bl to continue trialing
+	- [#244](https://github.com/hyphacoop/organizing/issues/244) yj to confirm then close
+	- [#253](https://github.com/hyphacoop/organizing/issues/253) bl has a comment for el to answer
+	- [#168](https://github.com/hyphacoop/organizing/issues/168)
 	    - yj: voipms has more features: built-in voicemail, multiple channels, long distance calls, etc.
 	    - yj: monthly cost, but seems like a good featureful option for long term
         - bl: can we use for jitsi call in?
@@ -49,8 +49,8 @@ Notetaker:  bl
             - yj: Canada has ~$4 monthly cost / per minute billing, $3 for a Spain number
             - bl: we may need this to run infra for people
         - #todo:yj make a phone call so we don't get "archived"
-    - #172 related to reliability of services, moving priority up to 2 stars!
-    - #262 #todo:el investigate, probably rebrandly broke
+    - [#172](https://github.com/hyphacoop/organizing/issues/172) related to reliability of services, moving priority up to 2 stars!
+    - [#262](https://github.com/hyphacoop/organizing/issues/262) #todo:el investigate, probably rebrandly broke
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-04-15-all-hands.md
+++ b/_posts/meeting-notes/2020-04-15-all-hands.md
@@ -49,31 +49,31 @@ Notetaker:  el :raising_hand: el, bl, dc, pc, uv, gi, yj
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #240 done
+	- [#240](https://github.com/hyphacoop/organizing/issues/240) done
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #95 finished today IP agreement will be applied to anyone that we hire
+	- [#95](https://github.com/hyphacoop/organizing/issues/95) finished today IP agreement will be applied to anyone that we hire
 	    - need respond from dc
-	- #201 needs review from uv
-	- #35 going to wait a couple weeks for things to setle down for a bit
-	- #244 keep an eye on it to make sure it is renewed next week
-	- #133 still have to do this and hire non-members
+	- [#201](https://github.com/hyphacoop/organizing/issues/201) needs review from uv
+	- [#35](https://github.com/hyphacoop/organizing/issues/35) going to wait a couple weeks for things to setle down for a bit
+	- [#244](https://github.com/hyphacoop/organizing/issues/244) keep an eye on it to make sure it is renewed next week
+	- [#133](https://github.com/hyphacoop/organizing/issues/133) still have to do this and hire non-members
 	    - don't have IP agreement for non-member yet
-	- #77 pull request opened in the handbook, announcment on twitter
-	- #261 we might get the 75% support applied for the 10% subsidy program
+	- [#77](https://github.com/hyphacoop/organizing/issues/77) pull request opened in the handbook, announcment on twitter
+	- [#261](https://github.com/hyphacoop/organizing/issues/261) we might get the 75% support applied for the 10% subsidy program
 	    - updated requirement in the thread
 	    - bl: is it 75% on the payroll or on Jan and Feb?
 	        - need research?
-	- #262 shortlinks api broke, el needs to fix
+	- [#262](https://github.com/hyphacoop/organizing/issues/262) shortlinks api broke, el needs to fix
 	    - yj: may scrap rebrandly completely
-	- #102 no updates
-	- #250 did some hiring things today next step create hiring process
+	- [#102](https://github.com/hyphacoop/organizing/issues/102) no updates
+	- [#250](https://github.com/hyphacoop/organizing/issues/250) did some hiring things today next step create hiring process
 	    - bl: doing research on domestic and remote and need to confirm with accuntent
 - Triage NEW tasks :new:
 	- None to triage
 - Assign [UNASSIGNED][l-none] tasks :briefcase:
 	- _skipped_
 - Any issues we should discuss?
-    - #131 talked about yesterday and duplicate some internal addresses
+    - [#131](https://github.com/hyphacoop/organizing/issues/131) talked about yesterday and duplicate some internal addresses
         - document email setup
         - update inventory
         - yj to run show and tell on email

--- a/_posts/meeting-notes/2020-04-16-finance.md
+++ b/_posts/meeting-notes/2020-04-16-finance.md
@@ -36,16 +36,16 @@ Notetaker:  yj
 - Review DONE tasks :tada:
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-    - #185 Expense reimbursement
+    - [#185](https://github.com/hyphacoop/organizing/issues/185) Expense reimbursement
         - yj: review and merge
         - yj: bug ppl to file their stuff (bl and yj need to file)
-	- #250 Hiring process (current understanding)
+	- [#250](https://github.com/hyphacoop/organizing/issues/250) Hiring process (current understanding)
 	    - Domestic: hire person, not company, no HST, Wagepoint payroll, issue T4A, no EI/CPP/vacation/public holiday pay, flexible clip
 	        - yj: update spreadsheet to take care of no clip passthroughs
 	    - Foreign: hire person/company, no HST bc foreign, TransferWise (contract in CAD), no T4A, just an invoice, not thru Wagepoint
 	        - bl: deal with IP agreement (Operations WG)
-    - #120 #155 bl to confirm with Hema then we can wrap these
-    - #109 Determine system for storing confidential employee information
+    - [#120](https://github.com/hyphacoop/organizing/issues/120) [#155](https://github.com/hyphacoop/organizing/issues/155) bl to confirm with Hema then we can wrap these
+    - [#109](https://github.com/hyphacoop/organizing/issues/109) Determine system for storing confidential employee information
         - bl: storing employee info is now more important bc of hiring
         - assigned to yj
 

--- a/_posts/meeting-notes/2020-04-20-infrastructure.md
+++ b/_posts/meeting-notes/2020-04-20-infrastructure.md
@@ -39,14 +39,14 @@ How is everyone surviving these past week?
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- #244 will be this week!
-	- #246 el needs to do still, write policy on covid page
-	- #239 ongoing
-	- #262 shortlinks, el checked config files
+	- [#244](https://github.com/hyphacoop/organizing/issues/244) will be this week!
+	- [#246](https://github.com/hyphacoop/organizing/issues/246) el needs to do still, write policy on covid page
+	- [#239](https://github.com/hyphacoop/organizing/issues/239) ongoing
+	- [#262](https://github.com/hyphacoop/organizing/issues/262) shortlinks, el checked config files
 	    - el: logged in to rebrandly, things seem normal
 	    - bl: pls write comment in issue what you have done so results don't get duplicated
 	    - yj: will take this on, look at rebrandly logs and see if makes more sense to do custom js thing
-	- #131 email
+	- [#131](https://github.com/hyphacoop/organizing/issues/131) email
         - el: don't want to break something
 	    - yj: fixed `opportunities@`
 	    - bl: how can we ensure things move forward from here?
@@ -58,13 +58,13 @@ How is everyone surviving these past week?
 	    - set deadline to **April 27, 2020** to complete, so we can give update on next full all hands
 	    - yj: at coming standup, will ask ppl what email we need some services to go to (e.g. hubspot)
 	    - moved to high priority
-	- #175 passbolt
+	- [#175](https://github.com/hyphacoop/organizing/issues/175) passbolt
 	    - yj: want to backup nightly, phase 1 just between yj and el to start!
-	- #253 "ansible stuff"
+	- [#253](https://github.com/hyphacoop/organizing/issues/253) "ansible stuff"
 	    - bl: now less urgent, should continue conversation, but less urgent than emails
 	    - yj: making 1 star, but if BBB project comes in this will be bumped
 	    - bl: will keep looking for ways to fund this in the meantime
-	- #265 label
+	- [#265](https://github.com/hyphacoop/organizing/issues/265) label
 	    - bl discussed how this works and where we're at
 	    - yj taking this on, try to understand how this works...
 	    - bl: lower priority than email (2 star) but pretty high

--- a/_posts/meeting-notes/2020-04-22-governance.md
+++ b/_posts/meeting-notes/2020-04-22-governance.md
@@ -39,35 +39,35 @@ Notetaker:  bl
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- ...
 - [`wg:gov`][l-gov] label review
-    - #101 dc: been drafting them, expect to take 3h, should be done by eod
-    - #133 bl: I haven't start, both for members and contractors, will fork into two tasks
-    - #155 bl: will call Hema. Scenario example very helpful
+    - [#101](https://github.com/hyphacoop/organizing/issues/101) dc: been drafting them, expect to take 3h, should be done by eod
+    - [#133](https://github.com/hyphacoop/organizing/issues/133) bl: I haven't start, both for members and contractors, will fork into two tasks
+    - [#155](https://github.com/hyphacoop/organizing/issues/155) bl: will call Hema. Scenario example very helpful
         - bl: how to doc HST stuff?
             - dc: can have HST subsection in Finance page
             - bl: will keep HST scenarios in Finance tab
-    - #102 AGM next meeting
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) AGM next meeting
         - dc: may try to push to June
         - bl: not reason to have in May
     - handbook#13 after bylaws
-    - #202 peer feedback
+    - [#202](https://github.com/hyphacoop/organizing/issues/202) peer feedback
         - dc: we'll do it not pc bc of timing
 - [`wg:ops`][l-ops] label review
-    - #95 #201 waiting on feedback
-    - #250 hiring
+    - [#95](https://github.com/hyphacoop/organizing/issues/95) [#201](https://github.com/hyphacoop/organizing/issues/201) waiting on feedback
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring
         - dc: will eventually move process to handbook
         - bl: if we **hire foreign contractor**, contractor will invoice us as corporation or individual, we pay bills via transferwise in one of the supported currencies, they have to take care of taxes
         - bl: we need **transfer of IP for orgs** for contractor to sign
-    - #217 workplace health and safety
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) workplace health and safety
         - dc: we hav > 5 employees, need to do some extra stuff :D
         - bulletin board, went thru checklist, ...
         - need to have a policy on workplace safety and on workplace harassment, etc.
         - need to define a role "safety champion" do an online training :)
         - everyone probably has to do an online training
         - whole thing on MSD, one of our identified risks!
-    - #175 passbolt. bl: next on the list after emails, backup locally for now
-    - #97 time tracking. dc: some setup tasks not captured in finance role, this can be relevant, talk about it soon!
-    - #100 letterhead. dc: blocked on shortlinks, but can kinda move ahead
-    - #190 employment relationships. dc: ties into our other tasks, upgrade to 2 start
+    - [#175](https://github.com/hyphacoop/organizing/issues/175) passbolt. bl: next on the list after emails, backup locally for now
+    - [#97](https://github.com/hyphacoop/organizing/issues/97) time tracking. dc: some setup tasks not captured in finance role, this can be relevant, talk about it soon!
+    - [#100](https://github.com/hyphacoop/organizing/issues/100) letterhead. dc: blocked on shortlinks, but can kinda move ahead
+    - [#190](https://github.com/hyphacoop/organizing/issues/190) employment relationships. dc: ties into our other tasks, upgrade to 2 start
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-04-23-finance.md
+++ b/_posts/meeting-notes/2020-04-23-finance.md
@@ -45,16 +45,16 @@ Notetaker:  bl
 - Review DONE tasks :tada:
 	- none
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #120 bl will wrap this up next week
-	- #121 internal is mostly payroll
+	- [#120](https://github.com/hyphacoop/organizing/issues/120) bl will wrap this up next week
+	- [#121](https://github.com/hyphacoop/organizing/issues/121) internal is mostly payroll
 	    - yj: names... somebody who collects (external) and shares (internal) the harvest
-    - #185 reimbursement
+    - [#185](https://github.com/hyphacoop/organizing/issues/185) reimbursement
         - yj: didn't have to submit CC and just put a reasonable exchange rate (take CC rate)
         - bl: +1 to not require
-    - #250 hiring. untagged finance since work is done
-    - #109 confidential employee info
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring. untagged finance since work is done
+    - [#109](https://github.com/hyphacoop/organizing/issues/109) confidential employee info
         - yj to take it to infra to wrap up
-    - #155 bl will finish
+    - [#155](https://github.com/hyphacoop/organizing/issues/155) bl will finish
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-04-29-all-hands.md
+++ b/_posts/meeting-notes/2020-04-29-all-hands.md
@@ -53,19 +53,19 @@ Notetaker:  uv :raising_hand: pc, gi, yj, el, bl, dc, uv
 	- Adding in expense reimbursement
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
     - Feedback required
-        - #95: Draft and sign IP assigment agreemtent
-        - #185: Expense reimbursements
+        - [#95](https://github.com/hyphacoop/organizing/issues/95): Draft and sign IP assigment agreemtent
+        - [#185](https://github.com/hyphacoop/organizing/issues/185): Expense reimbursements
             - done but need people
-        - #74 needs 
-        - #100 create Hypha letterhead
+        - [#74](https://github.com/hyphacoop/organizing/issues/74) needs 
+        - [#100](https://github.com/hyphacoop/organizing/issues/100) create Hypha letterhead
     - Doing:
-        - #250 Developing hiring process (need to figure out how to hire/onboard a company as opposed to an individual)
+        - [#250](https://github.com/hyphacoop/organizing/issues/250) Developing hiring process (need to figure out how to hire/onboard a company as opposed to an individual)
         - Related issue: draft contractor agreements
             - dc: would be good to send out Friday this week - bl will do by EOD tomorrow
     - Todo:
-        - #35 Investigate interest free loan
+        - [#35](https://github.com/hyphacoop/organizing/issues/35) Investigate interest free loan
             - closing this issue as the main issue 
-        - #262 Shortlinks broken
+        - [#262](https://github.com/hyphacoop/organizing/issues/262) Shortlinks broken
             - Infra made a new tool
             - dc: spin up a new issue for final clean up
             - yj: it's functional but not "pretty"
@@ -74,14 +74,14 @@ Notetaker:  uv :raising_hand: pc, gi, yj, el, bl, dc, uv
                 - update handbook to reflect new shortlinks process
                 - scrub circle-ci job https://github.com/hyphacoop/worker-coop-scripts/blob/master/.circleci/config.yml#L85-L99 https://github.com/hyphacoop/worker-coop-scripts/pull/9
                 - add README to describe what this is and how it's deployed (can be 2 sentences)
-        - #261 Apply for covid19 financial support will be the catch all issue
-        - #131 Email policy
+        - [#261](https://github.com/hyphacoop/organizing/issues/261) Apply for covid19 financial support will be the catch all issue
+        - [#131](https://github.com/hyphacoop/organizing/issues/131) Email policy
             - cleaning up process from old to new system
             - will be well documented in the handbook
-        - #102 Prepare for AGM
+        - [#102](https://github.com/hyphacoop/organizing/issues/102) Prepare for AGM
             - will pick up next week and make decisions about date
     - Backlog
-        - #158 Upgrade bussiness phone number
+        - [#158](https://github.com/hyphacoop/organizing/issues/158) Upgrade bussiness phone number
             - yj: should be lower priority
             - made note in the issue to reflect the actual priority
             - yj: 

--- a/_posts/meeting-notes/2020-04-30-finance.md
+++ b/_posts/meeting-notes/2020-04-30-finance.md
@@ -36,16 +36,16 @@ Notetaker:  yj
 - Review DONE tasks :tada:
     - already archived
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #185 reimbursement
+	- [#185](https://github.com/hyphacoop/organizing/issues/185) reimbursement
 	    - just need to pay it
 	    - dc still needs to file
 	    - notified everyone except pc
 	    - bl unsure about pre-incorporation expenses
 	        - yj: can do as regular expense < $50,000
             - in QB count it as a incorporation date expense
-    - #155 org summary. bl will do it
-    - #109 determine system for storing confidential employee information. this is actually done! closed
-    - #261 covid-19 financial support. yj to call
+    - [#155](https://github.com/hyphacoop/organizing/issues/155) org summary. bl will do it
+    - [#109](https://github.com/hyphacoop/organizing/issues/109) determine system for storing confidential employee information. this is actually done! closed
+    - [#261](https://github.com/hyphacoop/organizing/issues/261) covid-19 financial support. yj to call
     - bl will take care of payroll for May, and we will assign Finance roles end-May
 
 ### Discussions

--- a/_posts/meeting-notes/2020-05-13-all-hands.md
+++ b/_posts/meeting-notes/2020-05-13-all-hands.md
@@ -56,8 +56,8 @@ Notetaker:  el :raising_hand: yj, bl, dc, uv, pc, gi, el
 	- #53 bl is doing
 - Assign [UNASSIGNED][l-none] tasks :briefcase:
 	- #286 to ops-wg
-	- #41 in org private
-	- #18 in org private block because of covid 
+	- private#41
+	- private#18 block because of covid 
 
 ### Working Group Updates
 

--- a/_posts/meeting-notes/2020-05-13-all-hands.md
+++ b/_posts/meeting-notes/2020-05-13-all-hands.md
@@ -44,20 +44,20 @@ Notetaker:  el :raising_hand: yj, bl, dc, uv, pc, gi, el
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #131 email address policy all done
+	- [#131](https://github.com/hyphacoop/organizing/issues/131) email address policy all done
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #95 discussion today
-	- #250 still in progress
-	- #280 all need to sign IP agreement Op aking this on
-	- #102 #TODO dc need to confirm time for June vitural AGM
+	- [#95](https://github.com/hyphacoop/organizing/issues/95) discussion today
+	- [#250](https://github.com/hyphacoop/organizing/issues/250) still in progress
+	- [#280](https://github.com/hyphacoop/organizing/issues/280) all need to sign IP agreement Op aking this on
+	- [#102](https://github.com/hyphacoop/organizing/issues/102) #TODO dc need to confirm time for June vitural AGM
 - Triage NEW tasks :new:
 	- infra reading
 	- purging room history
-	- #53 bl is doing
+	- [#53](https://github.com/hyphacoop/organizing/issues/53) bl is doing
 - Assign [UNASSIGNED][l-none] tasks :briefcase:
-	- #286 to ops-wg
-	- private#41
-	- private#18 block because of covid 
+	- [#286](https://github.com/hyphacoop/organizing/issues/286) to ops-wg
+	- [private#41](https://github.com/hyphacoop/organizing-private/issues/41)
+	- [private#18](https://github.com/hyphacoop/organizing-private/issues/18) block because of covid 
 
 ### Working Group Updates
 
@@ -103,7 +103,7 @@ Notetaker:  el :raising_hand: yj, bl, dc, uv, pc, gi, el
 
 ### Discussions
 
- - IP #95
+ - IP [#95](https://github.com/hyphacoop/organizing/issues/95)
      - drafted and well past review
      - dump into PDF and put into hellosign and all sign
      - bl and dc: anyone have concerns?

--- a/_posts/meeting-notes/2020-05-19-infrastructure.md
+++ b/_posts/meeting-notes/2020-05-19-infrastructure.md
@@ -39,13 +39,13 @@ _None_
 - Review DONE tasks :tada:
 	- None
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #246 el will write copy and ping bl to review in hackmd
+	- [#246](https://github.com/hyphacoop/organizing/issues/246) el will write copy and ping bl to review in hackmd
 	    - deadline Thursday, then finalize Friday (left comment in issue)
-	- private#48 discuss
-    - #282 yj: deal with multiple repos, el updating docs with cache impl
+	- [private#48](https://github.com/hyphacoop/organizing-private/issues/48) discuss
+    - [#282](https://github.com/hyphacoop/organizing/issues/282) yj: deal with multiple repos, el updating docs with cache impl
         - bl: eventually merge them, probably separate for now?
-    - private#58 yj: will finish up
-    - #288 yj: have all the pieces to make this work, need:
+    - [private#58](https://github.com/hyphacoop/organizing-private/issues/58) yj: will finish up
+    - [#288](https://github.com/hyphacoop/organizing/issues/288) yj: have all the pieces to make this work, need:
         - which rooms? bl: private rooms
         - how often? yj,el: run daily, keep 3 months of history
         - yj: run by all hands before making changes
@@ -77,8 +77,8 @@ _None_
             - yj: thinking about beta program, matrix helpful for feedback
         - yj: like "group policy" in windows
         - #todo bl: add summary of this to service reliability issue
-    - private#44 looks like a ded lead, moving to backlog
-    - #175 managing passbolt
+    - [private#44](https://github.com/hyphacoop/organizing-private/issues/44) looks like a ded lead, moving to backlog
+    - [#175](https://github.com/hyphacoop/organizing/issues/175) managing passbolt
         - yj: critical infra. run a second instance, a restored copy on el's infra (auto restore)
         - bl: not a block, but we should focus on moving things off our infra
         - el: if it goes down it takes a couple min to spin it back up

--- a/_posts/meeting-notes/2020-05-20-governance.md
+++ b/_posts/meeting-notes/2020-05-20-governance.md
@@ -44,28 +44,28 @@ Notetaker:  dc
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- ...
 - [`wg:gov`][l-gov] label review
-    - #102 June 13-14 
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) June 13-14 
         - "Thank you all for the quick response -- we have a new weekend to hold: June 13-14. with a backup with June 20-21 as backup.
             Formal notice will be given the first week of June. Holds in the calendar"
 - [`wg:ops`][l-ops] label review
-    - #280 WIP bl to update, then will then update #95, move that process
-    - #250 Develop hiring process. dc: PR to handbook on onboarding (updated issue to reflect that). What is this "summarize plan in handbook?" for finance
+    - [#280](https://github.com/hyphacoop/organizing/issues/280) WIP bl to update, then will then update [#95](https://github.com/hyphacoop/organizing/issues/95), move that process
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) Develop hiring process. dc: PR to handbook on onboarding (updated issue to reflect that). What is this "summarize plan in handbook?" for finance
         - bring together
             - https://handbook.hypha.coop/onboarding.html
             - checklist that isn't particularly targeted for ops person or new employee, but used to onboard hank https://handbook.hypha.coop/guides.html#onboarding-checklist
                 - pull some into onboard place
             - Finance section re: diff types of onboards https://handbook.hypha.coop/finance.html#gsthst-rt
             - double-check notes from internship+NL
-    - #217 H&S WIP no work in last couple weeks
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) H&S WIP no work in last couple weeks
         - let Hank know he needs to speak to WSIB person (dc) in event of injury
         - #todo bl add this to acknowledgement -> email to Dawn Walker <operations@hypha.coop>
-    - #288 Matrix history will discuss at all hands
-    - #190 Evaluate our conditions for interpreting employment relationships, sitting on this for now. dc: we are able to do this 
-    - #133 bl still assigned, before next wednesday
-    - #97 time-tracking park
-    - #202 next meeting? dc: bylaws more critical
-    - #273 bl: lower priority, move to backlog 
-    - #147 (dc: this process can fracture... I'm finding todos on here that are in other issues for ops and bizdev... confusing.)
+    - [#288](https://github.com/hyphacoop/organizing/issues/288) Matrix history will discuss at all hands
+    - [#190](https://github.com/hyphacoop/organizing/issues/190) Evaluate our conditions for interpreting employment relationships, sitting on this for now. dc: we are able to do this 
+    - [#133](https://github.com/hyphacoop/organizing/issues/133) bl still assigned, before next wednesday
+    - [#97](https://github.com/hyphacoop/organizing/issues/97) time-tracking park
+    - [#202](https://github.com/hyphacoop/organizing/issues/202) next meeting? dc: bylaws more critical
+    - [#273](https://github.com/hyphacoop/organizing/issues/273) bl: lower priority, move to backlog 
+    - [#147](https://github.com/hyphacoop/organizing/issues/147) (dc: this process can fracture... I'm finding todos on here that are in other issues for ops and bizdev... confusing.)
         - bl: will bring back feedback of things going into general that have existing issues (to ops + gov)
 
 ### Discussions

--- a/_posts/meeting-notes/2020-05-25-infrastructure.md
+++ b/_posts/meeting-notes/2020-05-25-infrastructure.md
@@ -40,13 +40,13 @@ Notetaker:  el
 - Review DONE tasks :tada:
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #246 el: go over pull request
-	- private#48: discussion item
-	- #282 update docs currently mix of Apache and Nginx
+	- [#246](https://github.com/hyphacoop/organizing/issues/246) el: go over pull request
+	- [private#48](https://github.com/hyphacoop/organizing-private/issues/48): discussion item
+	- [#282](https://github.com/hyphacoop/organizing/issues/282) update docs currently mix of Apache and Nginx
 	    - went over pr of next shortlink script version
-	- #175 backup and restore was done.
+	- [#175](https://github.com/hyphacoop/organizing/issues/175) backup and restore was done.
 	    - #todo: work on doc
-	- #288 matrix purge
+	- [#288](https://github.com/hyphacoop/organizing/issues/288) matrix purge
 	    - decide on repo
 	        - for settings of the scripts such as
 	            - shortlinks.csv (can be public, but are config)
@@ -63,11 +63,11 @@ Notetaker:  el
 	                - deploy keys
 	                - API keys
 	        - ansible setup server -> play hyphacoop/infra-ansible (fork of the public) -> play from config repo: BBB room config 
-	- private#58
+	- [private#58](https://github.com/hyphacoop/organizing-private/issues/58)
 	    - done
-	- private#52
+	- [private#52](https://github.com/hyphacoop/organizing-private/issues/52)
 	    - done
-	- private#41
+	- [private#41](https://github.com/hyphacoop/organizing-private/issues/41)
 	    - done
 
 ### Discussions
@@ -100,7 +100,7 @@ Notetaker:  el
             - #todo bl: inquire with koumbit
     - decide [our repo strategy](https://github.com/hyphacoop/organizing/issues/253#issuecomment-631551028)
         - _see discussion in task section_
-    - rename #253?
+    - rename [#253](https://github.com/hyphacoop/organizing/issues/253)?
         - Renamed
     - draft timeline
 - **business offering** (15 min): create a form draft for https://hackmd.io/bkD0GfXNQb6MCTkq-76MWQ

--- a/_posts/meeting-notes/2020-05-25-infrastructure.md
+++ b/_posts/meeting-notes/2020-05-25-infrastructure.md
@@ -41,7 +41,7 @@ Notetaker:  el
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- #246 el: go over pull request
-	- private #48: discussion item
+	- private#48: discussion item
 	- #282 update docs currently mix of Apache and Nginx
 	    - went over pr of next shortlink script version
 	- #175 backup and restore was done.
@@ -63,11 +63,11 @@ Notetaker:  el
 	                - deploy keys
 	                - API keys
 	        - ansible setup server -> play hyphacoop/infra-ansible (fork of the public) -> play from config repo: BBB room config 
-	- private #58
+	- private#58
 	    - done
-	- private #52
+	- private#52
 	    - done
-	- private #41
+	- private#41
 	    - done
 
 ### Discussions

--- a/_posts/meeting-notes/2020-05-27-all-hands.md
+++ b/_posts/meeting-notes/2020-05-27-all-hands.md
@@ -50,39 +50,39 @@ Notetaker:  uv :raising_hand: yj, bl, dc, uv, pc, gi, el
 
 - Archive DONE tasks :tada:
     - done!
-    - #45, #4, private#52, private#41 
+    - [#45](https://github.com/hyphacoop/organizing/issues/45), [#4](https://github.com/hyphacoop/organizing/issues/4), [private#52](https://github.com/hyphacoop/organizing-private/issues/52), [private#41](https://github.com/hyphacoop/organizing-private/issues/41) 
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-    - #280 (dc + uv to review)
-    - #261 apply for COVID financial support
+    - [#280](https://github.com/hyphacoop/organizing/issues/280) (dc + uv to review)
+    - [#261](https://github.com/hyphacoop/organizing/issues/261) apply for COVID financial support
         - looking at the CWCF
         - dc: potentially include legal/accounting consultation
-    - private#61 Open Collective set up 
+    - [private#61](https://github.com/hyphacoop/organizing-private/issues/61) Open Collective set up 
         - yj: got access to OC, update handbook, sponsorship
         - dc: language that needs to be updated
             - todo: folks to create individual accounts
         - yj: two modes - (1) receiving funds and (2) being a fiscal host for others
         - todo: create a new task for where to put the open collective (e.g., bbb, )
-    - private#53 HST
+    - [private#53](https://github.com/hyphacoop/organizing-private/issues/53) HST
         - next monday, june 1st send out 
         - todo: update handbook
         - yj: most invoices will include HST (except international)
-    - #250 Develop hiring process 
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) Develop hiring process 
         - PR to handbook needs to happen, in progress HST
         - bl to update the tax piece
-    - #102 Road to AGM
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) Road to AGM
         - #todo update the issue, send notice next week, anticipate pc returning 
-    - #95 Draft IP agreement doc
+    - [#95](https://github.com/hyphacoop/organizing/issues/95) Draft IP agreement doc
         - blocked on depends on Open Working document
-    - #286 Hiring for summer
+    - [#286](https://github.com/hyphacoop/organizing/issues/286) Hiring for summer
         - waiting for hw to get back to us on internship
 - Triage NEW tasks :new:
-    - private#53
+    - [private#53](https://github.com/hyphacoop/organizing-private/issues/53)
         - todo: rename Develop rate cards
         - first task is to capture existing quotes
         - bl assigned
-    - private#48 opportunity: Hypha hosted infrastructure as a service
+    - [private#48](https://github.com/hyphacoop/organizing-private/issues/48) opportunity: Hypha hosted infrastructure as a service
         - bl assigned
-    - #272 Host second design jam
+    - [#272](https://github.com/hyphacoop/organizing/issues/272) Host second design jam
         - gi assigned, priority **
         - hw expressed interest, potentially for gi to consider if internship happens, but not a blocker
 - Assign [UNASSIGNED][l-none] tasks :briefcase:

--- a/_posts/meeting-notes/2020-05-27-all-hands.md
+++ b/_posts/meeting-notes/2020-05-27-all-hands.md
@@ -50,19 +50,19 @@ Notetaker:  uv :raising_hand: yj, bl, dc, uv, pc, gi, el
 
 - Archive DONE tasks :tada:
     - done!
-    - #45, #4, organizing-private/#52, organizing-private/#41 
+    - #45, #4, private#52, private#41 
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
     - #280 (dc + uv to review)
     - #261 apply for COVID financial support
         - looking at the CWCF
         - dc: potentially include legal/accounting consultation
-    - Private #61 Open Collective set up 
+    - private#61 Open Collective set up 
         - yj: got access to OC, update handbook, sponsorship
         - dc: language that needs to be updated
             - todo: folks to create individual accounts
         - yj: two modes - (1) receiving funds and (2) being a fiscal host for others
         - todo: create a new task for where to put the open collective (e.g., bbb, )
-    - Private #53 HST
+    - private#53 HST
         - next monday, june 1st send out 
         - todo: update handbook
         - yj: most invoices will include HST (except international)
@@ -76,11 +76,11 @@ Notetaker:  uv :raising_hand: yj, bl, dc, uv, pc, gi, el
     - #286 Hiring for summer
         - waiting for hw to get back to us on internship
 - Triage NEW tasks :new:
-    - Private #53
+    - private#53
         - todo: rename Develop rate cards
         - first task is to capture existing quotes
         - bl assigned
-    - Private #48 opportunity: Hypha hosted infrastructure as a service
+    - private#48 opportunity: Hypha hosted infrastructure as a service
         - bl assigned
     - #272 Host second design jam
         - gi assigned, priority **

--- a/_posts/meeting-notes/2020-06-01-infrastructure.md
+++ b/_posts/meeting-notes/2020-06-01-infrastructure.md
@@ -41,17 +41,17 @@ Notetaker:  el
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 
 Doing:
-  - #246 discussion
-  - #239 #todo: follow up with Chris
-  - private#48
-  - private#58 #todo: pc read readings
-  - #288 still being worked on
+  - [#246](https://github.com/hyphacoop/organizing/issues/246) discussion
+  - [#239](https://github.com/hyphacoop/organizing/issues/239) #todo: follow up with Chris
+  - [private#48](https://github.com/hyphacoop/organizing-private/issues/48)
+  - [private#58](https://github.com/hyphacoop/organizing-private/issues/58) #todo: pc read readings
+  - [#288](https://github.com/hyphacoop/organizing/issues/288) still being worked on
 To do:
-  - #289 restarting prosdy fixes joining loop
-  - #253 tomorrow or Weds will have decision, sale ends in one week
-  - #276 low priority
-  - #147 all infra stuff done
-  - #175 still need documentation, currently being backed up
+  - [#289](https://github.com/hyphacoop/organizing/issues/289) restarting prosdy fixes joining loop
+  - [#253](https://github.com/hyphacoop/organizing/issues/253) tomorrow or Weds will have decision, sale ends in one week
+  - [#276](https://github.com/hyphacoop/organizing/issues/276) low priority
+  - [#147](https://github.com/hyphacoop/organizing/issues/147) all infra stuff done
+  - [#175](https://github.com/hyphacoop/organizing/issues/175) still need documentation, currently being backed up
   - hypha.coop#5 el: still working on pr
 
 ### OKRs
@@ -69,7 +69,7 @@ To do:
 
 ### Discussions
 
-- #246 BBB relating to meet.coop
+- [#246](https://github.com/hyphacoop/organizing/issues/246) BBB relating to meet.coop
     - pc: met with koumbit before
         - they are commited with open source
     - bl: Chris from webarch doing great stuff

--- a/_posts/meeting-notes/2020-06-08-infrastructure.md
+++ b/_posts/meeting-notes/2020-06-08-infrastructure.md
@@ -45,15 +45,15 @@ Notetaker:  yj
 	
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- #private/48 - Waiting on BizDev
-	- #256 
+	- [#256](https://github.com/hyphacoop/organizing/issues/256) 
 	    - Data policy done
 	    - working wiht bbb.coop
 	    - colaborate on bbb.coop ansible
-    - #282 - Rebrandly
-    - #288 - Room Purge
+    - [#282](https://github.com/hyphacoop/organizing/issues/282) - Rebrandly
+    - [#288](https://github.com/hyphacoop/organizing/issues/288) - Room Purge
         - notify people
     - #private/67 meet.coop
-    - #175 - passbolt instance
+    - [#175](https://github.com/hyphacoop/organizing/issues/175) - passbolt instance
         - bl: do we need to document what passwords exist on there for each group?
             - yj: has personal passwords in there
             - yj: but once the last person leaves a group, we're sol

--- a/_posts/meeting-notes/2020-06-10-all-hands.md
+++ b/_posts/meeting-notes/2020-06-10-all-hands.md
@@ -57,18 +57,18 @@ Notetaker:  bl :raising_hand: yj, bl, dc, gi, el, uv, pc
 	- archived all of the DONE tasks
 - Feedback Required tasks
     - dc: fiscal sponsorship page PR
-    - private#48 bl: need bizdev input, not urgent
-    - #95 bl: everyone pls sign the agreement
+    - [private#48](https://github.com/hyphacoop/organizing-private/issues/48) bl: need bizdev input, not urgent
+    - [#95](https://github.com/hyphacoop/organizing/issues/95) bl: everyone pls sign the agreement
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #250 hiring process. dc: we (ops) were gonna do it but we haven't
-	- private#61 OC account. dc: ppl can choose donations, etc. last piece
+	- [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process. dc: we (ops) were gonna do it but we haven't
+	- [private#61](https://github.com/hyphacoop/organizing-private/issues/61) OC account. dc: ppl can choose donations, etc. last piece
 	    - website marketing -> separate thread #todo
 	    - emails -> donate link
 	    - chat welcome text often gets ignored, propose more comprehensive plan
 	        - need to develop text
 	        - #todo track on new issue about marketing plan for OC donations to BBB (someone from infra and bizdev to peer on)
-	- #261 covid suppoer. bl: will do the cwcf email
-	- #102 AGM. dc: we're doing it!
+	- [#261](https://github.com/hyphacoop/organizing/issues/261) covid suppoer. bl: will do the cwcf email
+	- [#102](https://github.com/hyphacoop/organizing/issues/102) AGM. dc: we're doing it!
 	    - bl: when is the WG updates?
 	        - dc: decision and value section, early early
 - Triage NEW tasks :new:

--- a/_posts/meeting-notes/2020-06-22-infrastructure.md
+++ b/_posts/meeting-notes/2020-06-22-infrastructure.md
@@ -43,9 +43,9 @@ Notetaker:  pc
 - Review DONE tasks :tada:
 	- none!
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-    - private#48 hypha hosted infra.
+    - [private#48](https://github.com/hyphacoop/organizing-private/issues/48) hypha hosted infra.
     - DOING
-	- #246 tuning bbb.
+	- [#246](https://github.com/hyphacoop/organizing/issues/246) tuning bbb.
 	    - bl: have you set up meet.coop ansible roles? not yet.
 	    - ben: chris+luke = tech focus; get ppl paid. olli+xxx interested in how decision-making happens.
 	        - tech + decision-making mustc come before marketing + money.
@@ -54,32 +54,32 @@ Notetaker:  pc
         - meet.coop = shared platform for member orgs to monetize. work is in creating and managing users, not maintaining backend.
         - open2020. went well. only complaint = separate video streams are a hassle that need processing.
         - moved to todo. will close when ansible roles are used to reproduce service.
-    - #282 migrate shortlinks
+    - [#282](https://github.com/hyphacoop/organizing/issues/282) migrate shortlinks
         - in progress: el working on ansible role for web server, which can include hosting shortlink service
-    - #288 matrix history purge
+    - [#288](https://github.com/hyphacoop/organizing/issues/288) matrix history purge
         - current status: el making a script for it
-    - private#67 meet.coop membership
+    - [private#67](https://github.com/hyphacoop/organizing-private/issues/67) meet.coop membership
         - current status: bl needs to continue circling back with event organizers.
     - TODO
-        - private#68 joining webarch.
+        - [private#68](https://github.com/hyphacoop/organizing-private/issues/68) joining webarch.
             - current status: move to BACKLOG
-        - #239 next cloud for project
+        - [#239](https://github.com/hyphacoop/organizing/issues/239) next cloud for project
             - no updates.
             - #movedto backlog
             - #todo talk to chris@webarch (ben)
-        - #289 jitsi connection loop
+        - [#289](https://github.com/hyphacoop/organizing/issues/289) jitsi connection loop
             - talking to ryan
             - bl: do we need to keep maintaining this?
             - yj: nice to have fallback. +1 bl
             - pc: can our fallback be someone else's?
             - revist: when new version comes out and/or after migration to hypha-hosted.
-        - #253 internal infra
+        - [#253](https://github.com/hyphacoop/organizing/issues/253) internal infra
             - #moved to DOING
-        - #276 prometheus
+        - [#276](https://github.com/hyphacoop/organizing/issues/276) prometheus
             - no updates.
-        - #175 passbolt management
+        - [#175](https://github.com/hyphacoop/organizing/issues/175) passbolt management
             - #moved to DONE. closed
-        - #147 small tasks
+        - [#147](https://github.com/hyphacoop/organizing/issues/147) small tasks
             - pc to use bot's secret for automated tasks
                 - DONE: https://github.com/hyphacoop/handbook/pull/89
 

--- a/_posts/meeting-notes/2020-06-24-all-hands.md
+++ b/_posts/meeting-notes/2020-06-24-all-hands.md
@@ -62,19 +62,19 @@ Notetaker:  Notetaker: pc :raising_hand: yj, dc, gi, el, bl, uv, pc
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- 3x... #202, #167, #101, #102, #185
+	- 3x... [#202](https://github.com/hyphacoop/organizing/issues/202), [#167](https://github.com/hyphacoop/organizing/issues/167), [#101](https://github.com/hyphacoop/organizing/issues/101), [#102](https://github.com/hyphacoop/organizing/issues/102), [#185](https://github.com/hyphacoop/organizing/issues/185)
 	- bl: bylaws? dc: later issue.
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
  	- FEEDBACK REQUIRED
-        - #304 director resolution. reassigning from pc to bl.
-        - private#61 opencollective. clarify task ownership. bl adding text. gi reviewing. ~~welcome text on bbb~~
-        - #261 covid-19 fin support. #todo re-scope + cross off todos.
-        - private#65 CWCF emergency relief. ...
-        - #253 hypha infra. worked on timeline in infra meeting. bought server. el+yj setting up.
+        - [#304](https://github.com/hyphacoop/organizing/issues/304) director resolution. reassigning from pc to bl.
+        - [private#61](https://github.com/hyphacoop/organizing-private/issues/61) opencollective. clarify task ownership. bl adding text. gi reviewing. ~~welcome text on bbb~~
+        - [#261](https://github.com/hyphacoop/organizing/issues/261) covid-19 fin support. #todo re-scope + cross off todos.
+        - [private#65](https://github.com/hyphacoop/organizing-private/issues/65) CWCF emergency relief. ...
+        - [#253](https://github.com/hyphacoop/organizing/issues/253) hypha infra. worked on timeline in infra meeting. bought server. el+yj setting up.
             - doc of setup: https://hackmd.io/pElXZTnUTRO1zApxpdBWDw?view
             - dc: isn't some of this on github? bl: not moving github stuff.
             - bl will make tasks for each service and group them into a milestone
-        - #307 agm wrap-up. commit notes incoming.
+        - [#307](https://github.com/hyphacoop/organizing/issues/307) agm wrap-up. commit notes incoming.
             - dc: publish publicly?
             - bl: slides too? dc: private repo. prob not required.
             - bl: some client financials in slides, but don't think big problem -- coarse.
@@ -83,8 +83,8 @@ Notetaker:  Notetaker: pc :raising_hand: yj, dc, gi, el, bl, uv, pc
             - bylaws ready to be publicized (and shared with hema)
             - uv: #todo sched bizdev meeting (suggestion: next thurs)
     - TODO
-        - #250 hiring process. wip.
-        - #311 anti-black racism plan. todo discussion.
+        - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process. wip.
+        - [#311](https://github.com/hyphacoop/organizing/issues/311) anti-black racism plan. todo discussion.
             - dc: i feel there should be an all-hands discussion. +1 patcon
             - bl: CWCF is having similar discussion. should we work with them? dc: our own work != wider work. CWCF is taking a break on meeting too after next coffee session.
             - pc: slot outside all-hands on sat? dc+bl: prefer not weekend.

--- a/_posts/meeting-notes/2020-06-25-finance.md
+++ b/_posts/meeting-notes/2020-06-25-finance.md
@@ -36,10 +36,10 @@ Notetaker:  bl
 - Review DONE tasks :tada:
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #261 COVID-19 financial support closed
-	- #278 member loan emergency credt -> backlog
-	- #250 hiring process -> untag Finance
-	- #306 Receive payment without invoice -> closed
+	- [#261](https://github.com/hyphacoop/organizing/issues/261) COVID-19 financial support closed
+	- [#278](https://github.com/hyphacoop/organizing/issues/278) member loan emergency credt -> backlog
+	- [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process -> untag Finance
+	- [#306](https://github.com/hyphacoop/organizing/issues/306) Receive payment without invoice -> closed
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-06-29-infrastructure.md
+++ b/_posts/meeting-notes/2020-06-29-infrastructure.md
@@ -39,13 +39,13 @@ Notetaker:  bl
 - Review DONE tasks :tada:
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-    - private#48 infra as a service. still blocked on bizdev
-	- #288 matrix history/purge. try to finish for next week
-	- private#67 meet.coop. now yj knows how deploy this, will do
-	- #282 rebrandly. in progress, moved to prod env
-	- #276 prometheus server. end-September target
+    - [private#48](https://github.com/hyphacoop/organizing-private/issues/48) infra as a service. still blocked on bizdev
+	- [#288](https://github.com/hyphacoop/organizing/issues/288) matrix history/purge. try to finish for next week
+	- [private#67](https://github.com/hyphacoop/organizing-private/issues/67) meet.coop. now yj knows how deploy this, will do
+	- [#282](https://github.com/hyphacoop/organizing/issues/282) rebrandly. in progress, moved to prod env
+	- [#276](https://github.com/hyphacoop/organizing/issues/276) prometheus server. end-September target
 	- small tasks. nothing there. start putting task at the top post!
-	- #125 reset access token. yj to ping pc to clean this up
+	- [#125](https://github.com/hyphacoop/organizing/issues/125) reset access token. yj to ping pc to clean this up
 - Triage
     - Discuss all issues in [Migrate internal services to Hypha server](https://github.com/hyphacoop/organizing/milestone/1) milestone
     - #todo el: file a task to re-visit how to do DNS and IP addresses in Oct (Digital Ocean, OVH, Ansible, etc.)

--- a/_posts/meeting-notes/2020-07-02-governance.md
+++ b/_posts/meeting-notes/2020-07-02-governance.md
@@ -45,9 +45,9 @@ Final review section on Bylaws: https://docs.google.com/document/d/1QN8QzmSnnj1G
 	- AGM!!!
 	- Working open, hiring
 - [`wg:gov`][l-gov] label review
-    - #101 bylaws. dc to get ready for review
+    - [#101](https://github.com/hyphacoop/organizing/issues/101) bylaws. dc to get ready for review
         - finance to review Section 6, 7, and Appendix
-    - #102 AGM. dc sent notice and started drafting agenda and package
+    - [#102](https://github.com/hyphacoop/organizing/issues/102) AGM. dc sent notice and started drafting agenda and package
         - dc reached out to elon. what to do?
         - video requirement. discuss at All Hands
         - agenda pretty flexible
@@ -57,19 +57,19 @@ Final review section on Bylaws: https://docs.google.com/document/d/1QN8QzmSnnj1G
             - notetaker and timekeeper
             - all hands, dc to bring up fun activity
     - handbook#13 duties for roles. changed to dc
-    - #202 feedback model. changed to dc, check in with pc
+    - [#202](https://github.com/hyphacoop/organizing/issues/202) feedback model. changed to dc, check in with pc
         - no pre-AGM activity
         - no plan to have this on agenda for AGM in this new format
         - pick up again next week
-    - #167 biz plan. discuss at bizdev call
-    - #104 amend articles. need to agree at AGM. $100
-    - #234 revisit org values
+    - [#167](https://github.com/hyphacoop/organizing/issues/167) biz plan. discuss at bizdev call
+    - [#104](https://github.com/hyphacoop/organizing/issues/104) amend articles. need to agree at AGM. $100
+    - [#234](https://github.com/hyphacoop/organizing/issues/234) revisit org values
     - handbook#14 good member. draft for AGM, move into peer feedback
         - e.g. can we prepare two meetings?
         - talk about this at all hands next week, then followed by AGM refining
 - [`wg:ops`][l-ops] label review
-    - #217 wsib. moved to To Do
-    - #190 evaluate our conditions for interpreting employment relationships
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) wsib. moved to To Do
+    - [#190](https://github.com/hyphacoop/organizing/issues/190) evaluate our conditions for interpreting employment relationships
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-07-08-all-hands.md
+++ b/_posts/meeting-notes/2020-07-08-all-hands.md
@@ -47,29 +47,29 @@ Notetaker:  bl :raising_hand: yj, dc, gi, el, uv, pc, bl
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #253 move infra to prod
-	- private#61 Open Collective
-	- private#71 email leak
-	- #304 resolutions template
-	- #306 handle donations
-	- #261 covid-19 financial support
+	- [#253](https://github.com/hyphacoop/organizing/issues/253) move infra to prod
+	- [private#61](https://github.com/hyphacoop/organizing-private/issues/61) Open Collective
+	- [private#71](https://github.com/hyphacoop/organizing-private/issues/71) email leak
+	- [#304](https://github.com/hyphacoop/organizing/issues/304) resolutions template
+	- [#306](https://github.com/hyphacoop/organizing/issues/306) handle donations
+	- [#261](https://github.com/hyphacoop/organizing/issues/261) covid-19 financial support
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- private#48 infra as service
+	- [private#48](https://github.com/hyphacoop/organizing-private/issues/48) infra as service
 	    - use as input for business strategy
 	    - decide at next bizdev meeting
-	- #307 AGM wrap up. dc working on it. resolutions have to be signed
-	- private#65 had call with Kaye. now clear on how/what to apply
-	- #323 FY1 filing
-	- #313 server setup and access
+	- [#307](https://github.com/hyphacoop/organizing/issues/307) AGM wrap up. dc working on it. resolutions have to be signed
+	- [private#65](https://github.com/hyphacoop/organizing-private/issues/65) had call with Kaye. now clear on how/what to apply
+	- [#323](https://github.com/hyphacoop/organizing/issues/323) FY1 filing
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) server setup and access
 	    - staging area
 	    - give everyone VPN access
 	    - document everything in github
-    - #322 budgeting for next
+    - [#322](https://github.com/hyphacoop/organizing/issues/322) budgeting for next
         - finance starting process to budget together
         - WGs need to report what they want money for
-    - private#72 COMPOST. tracking grant proposal
-    - #150 hiring process. dc needs to do some cleanup here
-    - #311 anti-black racism. dc thinks ops needs to take it up
+    - [private#72](https://github.com/hyphacoop/organizing-private/issues/72) COMPOST. tracking grant proposal
+    - [#150](https://github.com/hyphacoop/organizing/issues/150) hiring process. dc needs to do some cleanup here
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) anti-black racism. dc thinks ops needs to take it up
 - Triage NEW tasks :new:
 	- ...
 - Assign [UNASSIGNED][l-none] tasks :briefcase:

--- a/_posts/meeting-notes/2020-07-13-infrastructure.md
+++ b/_posts/meeting-notes/2020-07-13-infrastructure.md
@@ -43,19 +43,19 @@ Notetaker:  bl
 
 - Review DONE tasks :tada:
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #288 matrix purge
+	- [#288](https://github.com/hyphacoop/organizing/issues/288) matrix purge
 	    - bl: does it cause load?
             - yj: not really
-    - private#67 meet.coop. on hold
-    - #282 retire rebrandly. wait till ansible repo is up. blocked
-    - #125 reset access tokens to roobot
-    - #246 BBB ansibles blocked on Meet.coop
-    - #276 prometheus. wip
-    - #319 automated data backup
+    - [private#67](https://github.com/hyphacoop/organizing-private/issues/67) meet.coop. on hold
+    - [#282](https://github.com/hyphacoop/organizing/issues/282) retire rebrandly. wait till ansible repo is up. blocked
+    - [#125](https://github.com/hyphacoop/organizing/issues/125) reset access tokens to roobot
+    - [#246](https://github.com/hyphacoop/organizing/issues/246) BBB ansibles blocked on Meet.coop
+    - [#276](https://github.com/hyphacoop/organizing/issues/276) prometheus. wip
+    - [#319](https://github.com/hyphacoop/organizing/issues/319) automated data backup
         - KVM encrypts a VM image, then puts into directory, sync into SMB share
         - yj: walk thru of all this at some point
-    - #317 self-deployed BBB + Greenlight and relation to Meet.coop -> blocked
-    - private#48 infra as a service -> blocked
+    - [#317](https://github.com/hyphacoop/organizing/issues/317) self-deployed BBB + Greenlight and relation to Meet.coop -> blocked
+    - [private#48](https://github.com/hyphacoop/organizing-private/issues/48) infra as a service -> blocked
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-07-16-finance.md
+++ b/_posts/meeting-notes/2020-07-16-finance.md
@@ -34,15 +34,15 @@ Notetaker:  yj
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- #305
+	- [#305](https://github.com/hyphacoop/organizing/issues/305)
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #155
-	- #324 - pending
-	- private#65 - ben apply for 2 grants
-	    - private#80
-	- #323 push back
-	- #322 - todo
-	- #124 
+	- [#155](https://github.com/hyphacoop/organizing/issues/155)
+	- [#324](https://github.com/hyphacoop/organizing/issues/324) - pending
+	- [private#65](https://github.com/hyphacoop/organizing-private/issues/65) - ben apply for 2 grants
+	    - [private#80](https://github.com/hyphacoop/organizing-private/issues/80)
+	- [#323](https://github.com/hyphacoop/organizing/issues/323) push back
+	- [#322](https://github.com/hyphacoop/organizing/issues/322) - todo
+	- [#124](https://github.com/hyphacoop/organizing/issues/124) 
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-07-16-finance.md
+++ b/_posts/meeting-notes/2020-07-16-finance.md
@@ -38,8 +38,8 @@ Notetaker:  yj
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- #155
 	- #324 - pending
-	- private #65 - ben apply for 2 grants
-	    - #80
+	- private#65 - ben apply for 2 grants
+	    - private#80
 	- #323 push back
 	- #322 - todo
 	- #124 

--- a/_posts/meeting-notes/2020-07-20-infrastructure.md
+++ b/_posts/meeting-notes/2020-07-20-infrastructure.md
@@ -43,7 +43,7 @@ Notetaker:  el
 	- #313 still being worked on
 	- #329 #todo:bl add mailman to the list
 	- #288 #todo:el put scripts in a repo
-	- private #67 todo:infra-wg fill out time poll
+	- private#67 todo:infra-wg fill out time poll
 	- #314
 	- #282 #todo move the shortlinks .csv to configuration repo
 	- #329 wait for grant to come through

--- a/_posts/meeting-notes/2020-07-20-infrastructure.md
+++ b/_posts/meeting-notes/2020-07-20-infrastructure.md
@@ -40,14 +40,14 @@ Notetaker:  el
 - Review DONE tasks :tada:
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #313 still being worked on
-	- #329 #todo:bl add mailman to the list
-	- #288 #todo:el put scripts in a repo
-	- private#67 todo:infra-wg fill out time poll
-	- #314
-	- #282 #todo move the shortlinks .csv to configuration repo
-	- #329 wait for grant to come through
-	- #319 moved to backlog
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) still being worked on
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) #todo:bl add mailman to the list
+	- [#288](https://github.com/hyphacoop/organizing/issues/288) #todo:el put scripts in a repo
+	- [private#67](https://github.com/hyphacoop/organizing-private/issues/67) todo:infra-wg fill out time poll
+	- [#314](https://github.com/hyphacoop/organizing/issues/314)
+	- [#282](https://github.com/hyphacoop/organizing/issues/282) #todo move the shortlinks .csv to configuration repo
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) wait for grant to come through
+	- [#319](https://github.com/hyphacoop/organizing/issues/319) moved to backlog
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-07-22-all-hands.md
+++ b/_posts/meeting-notes/2020-07-22-all-hands.md
@@ -43,24 +43,24 @@ Notetaker:  bl :raising_hand: yj, dc, gi, el, uv, pc, bl
 
 - Archive DONE tasks :tada:
 	- hypha.coop#5 data policy on website now
-	- #305 quickbooks new features: multicurrency + tw integration + future invoices in our books
+	- [#305](https://github.com/hyphacoop/organizing/issues/305) quickbooks new features: multicurrency + tw integration + future invoices in our books
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #190 some work is paid vs unpaid, but there are requirements around min wage. bl has added clarifications in handbook, unpaid work goes in as owner/volunteer, paid work is done by us as workers.
+	- [#190](https://github.com/hyphacoop/organizing/issues/190) some work is paid vs unpaid, but there are requirements around min wage. bl has added clarifications in handbook, unpaid work goes in as owner/volunteer, paid work is done by us as workers.
 	    - uv: how will labour patronage work?
 	    - hours can inform but will not be directly used to pay out if we have surplus
 	    - **consensed** to rename ourselves to _member-worker_ (not member-owner)
-	- #155 clarifies we are member-employees, etc.
+	- [#155](https://github.com/hyphacoop/organizing/issues/155) clarifies we are member-employees, etc.
 	- CWCF grant proposals
         - Emergency Relief 
 	    - Technical Assistance
 	        - application needs two references
             - ask lawyer for a quote?
-	- #288 matrix purge. el to wrap up for next week
-	- #313 server setup and access. being worked on, give ppl access and docs
-	- #282 rebrandly. el to wrap up for next week
-	- #323 tax return. wip
-	- #329 ASN. blocked on grant status
-	- #322 budgeting for next year. bl needs to do it in loomio
+	- [#288](https://github.com/hyphacoop/organizing/issues/288) matrix purge. el to wrap up for next week
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) server setup and access. being worked on, give ppl access and docs
+	- [#282](https://github.com/hyphacoop/organizing/issues/282) rebrandly. el to wrap up for next week
+	- [#323](https://github.com/hyphacoop/organizing/issues/323) tax return. wip
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) ASN. blocked on grant status
+	- [#322](https://github.com/hyphacoop/organizing/issues/322) budgeting for next year. bl needs to do it in loomio
 - Triage NEW tasks :new:
     - none
 - Assign [UNASSIGNED][l-none] tasks :briefcase:

--- a/_posts/meeting-notes/2020-07-23-operations.md
+++ b/_posts/meeting-notes/2020-07-23-operations.md
@@ -45,8 +45,8 @@ Notetaker:  bl
     - Moving into thinking about collaborators?
         - ~~Hiring~~ Membership requirements (governance side)
             - What we look for in a member
-            - Member diversity & anti-black racism thread  #311
-            - Organizational values and how that gets translated to policies #76 #234 
+            - Member diversity & anti-black racism thread  [#311](https://github.com/hyphacoop/organizing/issues/311)
+            - Organizational values and how that gets translated to policies [#76](https://github.com/hyphacoop/organizing/issues/76) [#234](https://github.com/hyphacoop/organizing/issues/234) 
     - dc: A take on them grouped:
         - Continue to develop our governance muscles (slow burn)
         - *** Set up for Y2 and beyond (wrap up tasks on board) <-- Q3 emphasis

--- a/_posts/meeting-notes/2020-08-04-infrastructure.md
+++ b/_posts/meeting-notes/2020-08-04-infrastructure.md
@@ -34,14 +34,14 @@ Notetaker:  yj
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- #228 - add to Repo
-	- #313 - ongoing
-	- #282 - ongoing
-	- #314 - ongoing
-	- #329 - We will create to get a quote
-	- #125 - waiting on pat
-	- #317 - meet.coop
-	- #246 - meet.coop
+	- [#228](https://github.com/hyphacoop/organizing/issues/228) - add to Repo
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) - ongoing
+	- [#282](https://github.com/hyphacoop/organizing/issues/282) - ongoing
+	- [#314](https://github.com/hyphacoop/organizing/issues/314) - ongoing
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) - We will create to get a quote
+	- [#125](https://github.com/hyphacoop/organizing/issues/125) - waiting on pat
+	- [#317](https://github.com/hyphacoop/organizing/issues/317) - meet.coop
+	- [#246](https://github.com/hyphacoop/organizing/issues/246) - meet.coop
 	- 
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- ...

--- a/_posts/meeting-notes/2020-08-05-all-hands.md
+++ b/_posts/meeting-notes/2020-08-05-all-hands.md
@@ -42,29 +42,29 @@ Notetaker:  bl :raising_hand: yj, dc, gi, el, uv, pc, bl
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #65 CWCF emergency relief
-	- #190 handbook#13 #155 done
+	- [#65](https://github.com/hyphacoop/organizing/issues/65) CWCF emergency relief
+	- [#190](https://github.com/hyphacoop/organizing/issues/190) handbook#13 [#155](https://github.com/hyphacoop/organizing/issues/155) done
 	    - bl: after dc merges the PRs we will have updated docs about hypha
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #288 matrix histroy purge
+	- [#288](https://github.com/hyphacoop/organizing/issues/288) matrix histroy purge
         - el: move script to configuration repo and doc
         - csv file for shortlinks also goes to configuration repo
-    - #313 vpn access
+    - [#313](https://github.com/hyphacoop/organizing/issues/313) vpn access
         - el: will distribute keys, and share staging permissions
-    - #282 retire rebrandly
+    - [#282](https://github.com/hyphacoop/organizing/issues/282) retire rebrandly
         - el: csv to configurations repo and PR to handbook
-    - #323 corporate tax return
+    - [#323](https://github.com/hyphacoop/organizing/issues/323) corporate tax return
         - need
             - approve official financial reports of FY1 (next week's all hands is the board meeting)
             - AGM minutes approved and merged
             - resolutions signed
-    - #307 AGM wrap-up
-        - will finish these to unblock ben for #323
-    - #322 budgeting for next year
+    - [#307](https://github.com/hyphacoop/organizing/issues/307) AGM wrap-up
+        - will finish these to unblock ben for [#323](https://github.com/hyphacoop/organizing/issues/323)
+    - [#322](https://github.com/hyphacoop/organizing/issues/322) budgeting for next year
         - bl will do it soon-ish
-    - #329 ASN from ARIN
+    - [#329](https://github.com/hyphacoop/organizing/issues/329) ASN from ARIN
         - yj: make an account so we can request a quote
-    - #311 create a plan to counter anti-black racism and white supremacy
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) create a plan to counter anti-black racism and white supremacy
         - dc: OKRs will include this
 - Triage NEW tasks :new:
 	- ...

--- a/_posts/meeting-notes/2020-08-05-operations.md
+++ b/_posts/meeting-notes/2020-08-05-operations.md
@@ -42,16 +42,16 @@ Notetaker:  dc
     - signed off on Gov OKRs
     - signed off on Ops OKRs
 - Ops activites in next month
-    - #250 finalize hiring notes
-    - #217 workplace health and safety
-    - #273 revisit publishing our "templates" into hanbook
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) finalize hiring notes
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) workplace health and safety
+    - [#273](https://github.com/hyphacoop/organizing/issues/273) revisit publishing our "templates" into hanbook
         - making sure things land in handbook?
 - Things from last call related to ops: 
     - Moving into thinking about collaborators?
         - Hiring Membership requirements
         - What we look for in a member
-        - Member diversity & anti-black racism thread #311
-        - Organizational values and how that gets translated to policies #76 #234
+        - Member diversity & anti-black racism thread [#311](https://github.com/hyphacoop/organizing/issues/311)
+        - Organizational values and how that gets translated to policies [#76](https://github.com/hyphacoop/organizing/issues/76) [#234](https://github.com/hyphacoop/organizing/issues/234)
 - AGM/wrap-up stuff bl needs for Hema:
     - reconciled bank statements with board approval
         - bl to call board meeting for next week's all hands

--- a/_posts/meeting-notes/2020-08-19-all-hands.md
+++ b/_posts/meeting-notes/2020-08-19-all-hands.md
@@ -41,16 +41,16 @@ Notetaker:  pc + uv :raising_hand: yj, dc, gi, bl, el
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #282 Rebrandly task done
+	- [#282](https://github.com/hyphacoop/organizing/issues/282) Rebrandly task done
 
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
 	- Matrix purge task done
-	- #329 ARIN still working
-	- #313 VPN access provided
-	- #307 wrap up from AGM, skipping for nw since dc isn't here. uv having some troubles with gitbook
-	- #323 file corporate taxes discussion
-	- #322 business budgeting. down-prioritized.
-	- #311 _skipped_
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) ARIN still working
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) VPN access provided
+	- [#307](https://github.com/hyphacoop/organizing/issues/307) wrap up from AGM, skipping for nw since dc isn't here. uv having some troubles with gitbook
+	- [#323](https://github.com/hyphacoop/organizing/issues/323) file corporate taxes discussion
+	- [#322](https://github.com/hyphacoop/organizing/issues/322) business budgeting. down-prioritized.
+	- [#311](https://github.com/hyphacoop/organizing/issues/311) _skipped_
 - Triage NEW tasks :new:
 	- ...
 	- (udit flagged some things don't happen ever, e.g., up-prioritizing backlog items)
@@ -104,7 +104,7 @@ Notetaker:  pc + uv :raising_hand: yj, dc, gi, bl, el
 
 ### Discussions
 
-- ~~#322 budgeting~~
+- ~~[#322](https://github.com/hyphacoop/organizing/issues/322) budgeting~~
 - concerns about finance (bl)
     - uv: scope = bill payments for sept.
     - bl: one client hasn't paid. concerned.

--- a/_posts/meeting-notes/2020-08-27-infrastructure.md
+++ b/_posts/meeting-notes/2020-08-27-infrastructure.md
@@ -40,7 +40,7 @@ Notetaker:  pc
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- ...
-	- #313 server access
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) server access
 	    - everyone needs new infra keys
 	    - we won't pull repeatedly from github, in case github is compromised
 	    - patcon suggested using github keys as snapshot to set people up. others not in favour

--- a/_posts/meeting-notes/2020-09-16-all-hands.md
+++ b/_posts/meeting-notes/2020-09-16-all-hands.md
@@ -56,17 +56,17 @@ Notetaker:  pc
 - Archive DONE tasks :tada:
 	- ...
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #313 server
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) server
 	    - ournetworks delayed. no progress.
-	- private#92 IRP
+	- [private#92](https://github.com/hyphacoop/organizing-private/issues/92) IRP
 	    - patcon been working on it
 	        - booking some interviews with ppl who worked on comparable projects
 	        - some upcoming
 	    - due oct 9
 	    - research on prior art and products in space of helping ppl incorp (esp co-ops)
-	- #323 file returns
+	- [#323](https://github.com/hyphacoop/organizing/issues/323) file returns
 	    - hema changed them
-    - #351 wsib commercial insurance
+    - [#351](https://github.com/hyphacoop/organizing/issues/351) wsib commercial insurance
         - re: ben's questions...
         - insurer doesn't care about addresses. zensurance has almost never seen it. would be fees if we did need to add many.
         - can't drop electronic equipment coverage. need business office insured in order to have portable equip covered. we have lowest rate already.
@@ -77,18 +77,18 @@ Notetaker:  pc
         - +1 uv to insurance, as-is
         - uv: zensurance is monthly, which maybe nice.
         - dc: proposal: wait a week or two until Cisco gets back to us, then make a call.
-    - #311 anti-black racism.
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) anti-black racism.
         - no progress, but important
     - 2 STAR
-        - private#90 FSC grant
-        - #307 agm wrap
+        - [private#90](https://github.com/hyphacoop/organizing-private/issues/90) FSC grant
+        - [#307](https://github.com/hyphacoop/organizing/issues/307) agm wrap
             - uv: have some lawyer names who'd be willing to review bylaws
             - #todo add to CRM
-        - private#63 bl: just need to do this. will update handbook on close.
-        - #314 ansible.
-        - #308 Y2 biz plan. half done then delayed. upgrade prio.
-        - #250 hiring process. bump priority.
-        - #298 workflow for invoices/bookkeep. blocked on credit card. blocked on bank.
+        - [private#63](https://github.com/hyphacoop/organizing-private/issues/63) bl: just need to do this. will update handbook on close.
+        - [#314](https://github.com/hyphacoop/organizing/issues/314) ansible.
+        - [#308](https://github.com/hyphacoop/organizing/issues/308) Y2 biz plan. half done then delayed. upgrade prio.
+        - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process. bump priority.
+        - [#298](https://github.com/hyphacoop/organizing/issues/298) workflow for invoices/bookkeep. blocked on credit card. blocked on bank.
             - uv: there must be some other way to pay to unblock. we pay ourselves, so why not others.
             - #todo use another means we have access to
             - dc: we should get a checkbook. feels odd to not have it

--- a/_posts/meeting-notes/2020-09-30-operations.md
+++ b/_posts/meeting-notes/2020-09-30-operations.md
@@ -49,13 +49,13 @@ Important but don't have skills/member time:
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- ...
 - [`wg:gov`][l-gov] label review
-    - #250 hiring process. top priority. wrap-up.
-    - #104 amend articles. review material. goal end of sept. review pdf forms. look for errors. prepare for signing. confirm in-person signing requirement. money floater can be tapped.
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process. top priority. wrap-up.
+    - [#104](https://github.com/hyphacoop/organizing/issues/104) amend articles. review material. goal end of sept. review pdf forms. look for errors. prepare for signing. confirm in-person signing requirement. money floater can be tapped.
         - might be faster to his serviceON
-    - #307 wrap-up AGM. dc will do last piece of 304.
-    - #133 assignment agreement
+    - [#307](https://github.com/hyphacoop/organizing/issues/307) wrap-up AGM. dc will do last piece of 304.
+    - [#133](https://github.com/hyphacoop/organizing/issues/133) assignment agreement
         - good small item
-    - #14 good member accountability statement
+    - [#14](https://github.com/hyphacoop/organizing/issues/14) good member accountability statement
         - in AGM notes. draft accountability statement
         - good small item.
 - [`wg:ops`][l-ops] label review
@@ -71,8 +71,8 @@ Important but don't have skills/member time:
 
 Candidates for co-work:
 - discussed above in label review
-  - dc: #350 hiring process wrap-up. #307 AGM wrap-up.
-  - pc: #104 amend articles. #14 member accountability statement. #133 assignment agreement (stretch).
+  - dc: [#350](https://github.com/hyphacoop/organizing/issues/350) hiring process wrap-up. [#307](https://github.com/hyphacoop/organizing/issues/307) AGM wrap-up.
+  - pc: [#104](https://github.com/hyphacoop/organizing/issues/104) amend articles. [#14](https://github.com/hyphacoop/organizing/issues/14) member accountability statement. [#133](https://github.com/hyphacoop/organizing/issues/133) assignment agreement (stretch).
 
 
 

--- a/_posts/meeting-notes/2020-10-08-infrastructure.md
+++ b/_posts/meeting-notes/2020-10-08-infrastructure.md
@@ -36,12 +36,12 @@ Notetaker:  yj
 - Review DONE tasks :tada:
 	- none
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #329 - waitng on tomesh goahead
-	- #313 - bl and yj to check
-	- #314 - Documentation wiating on PR
-	- #125 - UNblock
-	- #317 - 
-	- #147 - Noop
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) - waitng on tomesh goahead
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) - bl and yj to check
+	- [#314](https://github.com/hyphacoop/organizing/issues/314) - Documentation wiating on PR
+	- [#125](https://github.com/hyphacoop/organizing/issues/125) - UNblock
+	- [#317](https://github.com/hyphacoop/organizing/issues/317) - 
+	- [#147](https://github.com/hyphacoop/organizing/issues/147) - Noop
 
 ### Discussions
 
@@ -54,7 +54,7 @@ Notetaker:  yj
         - installed as a distro, managed in GUI
         - offer to orgs as a service
         - firewalled in the VPN
-    - #168
+    - [#168](https://github.com/hyphacoop/organizing/issues/168)
     - yj: voipms?
     - yj: for meetcoop probably don't need our own PBX
         - better to get fixed-rate local lines (e.g. unlimited $20/month packages)

--- a/_posts/meeting-notes/2020-10-22-infrastructure.md
+++ b/_posts/meeting-notes/2020-10-22-infrastructure.md
@@ -43,11 +43,11 @@ Notetaker:  yj
 - Review DONE tasks :tada:
 	- BBB
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #329 - arin - tomesh waiting on
-	- #313 - testing needed
-	- #316 - Loomio - docs and backup
-	- #314 - Ansible - website - docs
-    - #168 - Upgrade business phone number
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) - arin - tomesh waiting on
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) - testing needed
+	- [#316](https://github.com/hyphacoop/organizing/issues/316) - Loomio - docs and backup
+	- [#314](https://github.com/hyphacoop/organizing/issues/314) - Ansible - website - docs
+    - [#168](https://github.com/hyphacoop/organizing/issues/168) - Upgrade business phone number
         - use voipms
         - yj: concerned about FreePBX hacks (sip in general)
     - roobot

--- a/_posts/meeting-notes/2020-10-28-all-hands.md
+++ b/_posts/meeting-notes/2020-10-28-all-hands.md
@@ -52,17 +52,17 @@ Notetaker:  el :raising_hand: dc, gi, pc, yj, uv, bl
 	- archived
 	
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #314 closed
-	- #329 in progress
-	- private#92 nothing to report
-	- #313 
-	- #316 moved to prod #todo:everyone go on loomio to test it
-	- #308 no update moved to To Do
-	- #351 its moving
-	- #134 been using it trying to up the limit, email in French and limit not increased, switched reaccuring paymet to CC, todo:yj speak with dc CWCF, sync with QB but not rules
+	- [#314](https://github.com/hyphacoop/organizing/issues/314) closed
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) in progress
+	- [private#92](https://github.com/hyphacoop/organizing-private/issues/92) nothing to report
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) 
+	- [#316](https://github.com/hyphacoop/organizing/issues/316) moved to prod #todo:everyone go on loomio to test it
+	- [#308](https://github.com/hyphacoop/organizing/issues/308) no update moved to To Do
+	- [#351](https://github.com/hyphacoop/organizing/issues/351) its moving
+	- [#134](https://github.com/hyphacoop/organizing/issues/134) been using it trying to up the limit, email in French and limit not increased, switched reaccuring paymet to CC, todo:yj speak with dc CWCF, sync with QB but not rules
 
 - To Do
-    - #311 no updates
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) no updates
 
 - Triage NEW tasks :new:
 	- ...

--- a/_posts/meeting-notes/2020-10-28-all-hands.md
+++ b/_posts/meeting-notes/2020-10-28-all-hands.md
@@ -54,7 +54,7 @@ Notetaker:  el :raising_hand: dc, gi, pc, yj, uv, bl
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
 	- #314 closed
 	- #329 in progress
-	- private #92 nothing to report
+	- private#92 nothing to report
 	- #313 
 	- #316 moved to prod #todo:everyone go on loomio to test it
 	- #308 no update moved to To Do

--- a/_posts/meeting-notes/2020-11-05-finance.md
+++ b/_posts/meeting-notes/2020-11-05-finance.md
@@ -32,10 +32,10 @@ Notetaker:  yj
 - Review DONE tasks :tada:
 	- ...
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #298 - Almost done, dome doc to re-sync
-	- #134 - auto pay left, have to re-call
-	- #255 - Implemented and Done \o/
-	- #218 - pulled out of backlog
+	- [#298](https://github.com/hyphacoop/organizing/issues/298) - Almost done, dome doc to re-sync
+	- [#134](https://github.com/hyphacoop/organizing/issues/134) - auto pay left, have to re-call
+	- [#255](https://github.com/hyphacoop/organizing/issues/255) - Implemented and Done \o/
+	- [#218](https://github.com/hyphacoop/organizing/issues/218) - pulled out of backlog
 
 ### Discussions
 

--- a/_posts/meeting-notes/2020-11-05-infrastructure.md
+++ b/_posts/meeting-notes/2020-11-05-infrastructure.md
@@ -34,13 +34,13 @@ Notetaker:  yj
 ### Task Board Review
 
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #329 - blocked on filling in form - TOMESH
-	- #313 - Ansible script - meet.coop
-	- #319 - Document Party
-	- #147 - Checked off
-	- #67 - closing off 
-	- #68 - Decide not to join
-	- #289 - Jitsi reboot cause loop
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) - blocked on filling in form - TOMESH
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) - Ansible script - meet.coop
+	- [#319](https://github.com/hyphacoop/organizing/issues/319) - Document Party
+	- [#147](https://github.com/hyphacoop/organizing/issues/147) - Checked off
+	- [#67](https://github.com/hyphacoop/organizing/issues/67) - closing off 
+	- [#68](https://github.com/hyphacoop/organizing/issues/68) - Decide not to join
+	- [#289](https://github.com/hyphacoop/organizing/issues/289) - Jitsi reboot cause loop
 	- #todo:yj make task to track next steps for phone stuff
 
 ### Discussions

--- a/_posts/meeting-notes/2020-11-11-gov-and-ops.md
+++ b/_posts/meeting-notes/2020-11-11-gov-and-ops.md
@@ -42,18 +42,18 @@ Notetaker:  pc
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- ...
 - [`wg:gov`][l-gov] label review
-    - #104. pushed to cowork
-    - #307. agm wrap. dc wants to claim. needs cleanup. not as big as looks. tasks are elsewhere.
-    - #14. what it means to be good member.
+    - [#104](https://github.com/hyphacoop/organizing/issues/104). pushed to cowork
+    - [#307](https://github.com/hyphacoop/organizing/issues/307). agm wrap. dc wants to claim. needs cleanup. not as big as looks. tasks are elsewhere.
+    - [#14](https://github.com/hyphacoop/organizing/issues/14). what it means to be good member.
         - pc was cowork. not done. related to agm wrap.
-    - #133. employee ack. pc not
-    - #311 anti-black racism.
+    - [#133](https://github.com/hyphacoop/organizing/issues/133). employee ack. pc not
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) anti-black racism.
         - dc had ideas after bizdev convo
         - dc: idea of low-hanging fruit. idea for small first step.
-    - #147 small tasks. not used.
+    - [#147](https://github.com/hyphacoop/organizing/issues/147) small tasks. not used.
 - [`wg:ops`][l-ops] label review
-    - #250 hiring process. SMALL. dc will do TODAY
-    - #217 workplace health/safety policy
+    - [#250](https://github.com/hyphacoop/organizing/issues/250) hiring process. SMALL. dc will do TODAY
+    - [#217](https://github.com/hyphacoop/organizing/issues/217) workplace health/safety policy
         - online training and draft policy
         - maybe a role (legal requirement)
             - must be person

--- a/_posts/meeting-notes/2020-11-17-infrastructure.md
+++ b/_posts/meeting-notes/2020-11-17-infrastructure.md
@@ -44,15 +44,15 @@ Notetaker:  el
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- private#68 archived
+	- [private#68](https://github.com/hyphacoop/organizing-private/issues/68) archived
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-	- #329 need org to look at contract, email Tim about IP addresses
-	- #313 docs
-	- #319 docs
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) need org to look at contract, email Tim about IP addresses
+	- [#313](https://github.com/hyphacoop/organizing/issues/313) docs
+	- [#319](https://github.com/hyphacoop/organizing/issues/319) docs
 
 ### Discussions
 
-- telephone stuff #todo:yj create issue for phone stuff -> #372
+- telephone stuff #todo:yj create issue for phone stuff -> [#372](https://github.com/hyphacoop/organizing/issues/372)
     - BBB phone number
     - jitsi number
     - SMS
@@ -71,7 +71,7 @@ Notetaker:  el
         - docs
     - External services
         - Decide in March
-- private#48 Opportunity: Hypha-hosted Infrastructure as a Service
+- [private#48](https://github.com/hyphacoop/organizing-private/issues/48) Opportunity: Hypha-hosted Infrastructure as a Service
     - focus on DWEB services?
         - becoming mainstream
         - managing matrix, IPFS...

--- a/_posts/meeting-notes/2020-11-17-infrastructure.md
+++ b/_posts/meeting-notes/2020-11-17-infrastructure.md
@@ -44,7 +44,7 @@ Notetaker:  el
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- private-#68 archived
+	- private#68 archived
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
 	- #329 need org to look at contract, email Tim about IP addresses
 	- #313 docs

--- a/_posts/meeting-notes/2020-11-25-all-hands.md
+++ b/_posts/meeting-notes/2020-11-25-all-hands.md
@@ -42,19 +42,19 @@ Notetaker:  gi :raising_hand: el, yj, uv, dc, pc, bl, gi
 - Archive DONE tasks :tada:
 	- 
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #329 ASN from ARIN
+	- [#329](https://github.com/hyphacoop/organizing/issues/329) ASN from ARIN
 	    - ping dc/ops for doc
-    - #313 server setup
+    - [#313](https://github.com/hyphacoop/organizing/issues/313) server setup
         - documentation stuff to get done
         - trying for this cycle
-    - #104 amend articles for not-for-profit
+    - [#104](https://github.com/hyphacoop/organizing/issues/104) amend articles for not-for-profit
         - dc to get to it tomorrow
-    - #134 cc
+    - [#134](https://github.com/hyphacoop/organizing/issues/134) cc
         - Submitted a request for auto payment
         - Marking as DONE
-    - #308 y2 strat
+    - [#308](https://github.com/hyphacoop/organizing/issues/308) y2 strat
         - done by tomorrow (biz-dev call)
-    - #311 anti-black racism plan
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) anti-black racism plan
         - no progress.
         - #todo scope a small piece we can act on
         - operations WG co-work for rescoping

--- a/_posts/meeting-notes/2020-12-09-all-hands.md
+++ b/_posts/meeting-notes/2020-12-09-all-hands.md
@@ -57,32 +57,32 @@ We'll have an autoresponder on the `hello@` and `members@` email and VM. Please 
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #308 finalize biz plan. cleaned up
+	- [#308](https://github.com/hyphacoop/organizing/issues/308) finalize biz plan. cleaned up
 	    - wrapped up. strat notes. finalized Y2 biz plan.
 	    - we are doing the things we said we would do! 
-    - #104 npo amendment. done today!
+    - [#104](https://github.com/hyphacoop/organizing/issues/104) npo amendment. done today!
         - once paid, doesn't require feedback from hypha, will drop priority
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire: (some of these are lower priority that got mixed in!)
-    - #329 ASN
+    - [#329](https://github.com/hyphacoop/organizing/issues/329) ASN
         - Waiting for tomesh to respond to SoW
         - tim replied that they will get back soon
-    - #313 server setup
+    - [#313](https://github.com/hyphacoop/organizing/issues/313) server setup
         - yj: Where is long draft supposed to be?
         - trying to differentiate permanent vs temporary materials. latter can go into hackpads.
         - hypha ops doesn't have any opinions, but offering follow up convos if needed
         - yj: seems like we're doing this already, just need to present this in infra meeting
-    - #311 anti-black racism.
+    - [#311](https://github.com/hyphacoop/organizing/issues/311) anti-black racism.
         - concrete actions required. dc has tabs open!
         - might need rescoping
-    - private#103 opportunity. patcon closing.
-    - #307 handbook issues.
+    - [private#103](https://github.com/hyphacoop/organizing-private/issues/103) opportunity. patcon closing.
+    - [#307](https://github.com/hyphacoop/organizing/issues/307) handbook issues.
         - dc will ping pc and close out a few lingering things
-    - #319 close off hopefully by tuesday
-    - #318 moved to doing
-    - #272 look and feel
+    - [#319](https://github.com/hyphacoop/organizing/issues/319) close off hopefully by tuesday
+    - [#318](https://github.com/hyphacoop/organizing/issues/318) moved to doing
+    - [#272](https://github.com/hyphacoop/organizing/issues/272) look and feel
         - dc: may need to revisit because of blog
-    - private#43 build relationships with coops. need to see if we want to be coop provider. punted to bizdev
-    - #372 set up telephone system: documentation required
+    - [private#43](https://github.com/hyphacoop/organizing-private/issues/43) build relationships with coops. need to see if we want to be coop provider. punted to bizdev
+    - [#372](https://github.com/hyphacoop/organizing/issues/372) set up telephone system: documentation required
 - Triage NEW tasks :new:
 	- ...
 - Assign [UNASSIGNED][l-none] tasks :briefcase:

--- a/_posts/meeting-notes/2020-12-09-all-hands.md
+++ b/_posts/meeting-notes/2020-12-09-all-hands.md
@@ -74,14 +74,14 @@ We'll have an autoresponder on the `hello@` and `members@` email and VM. Please 
     - #311 anti-black racism.
         - concrete actions required. dc has tabs open!
         - might need rescoping
-    - #103 private, opportunity. patcon closing.
+    - private#103 opportunity. patcon closing.
     - #307 handbook issues.
         - dc will ping pc and close out a few lingering things
     - #319 close off hopefully by tuesday
     - #318 moved to doing
     - #272 look and feel
         - dc: may need to revisit because of blog
-    - #43 private. build relationships with coops. need to see if we want to be coop provider. punted to bizdev
+    - private#43 build relationships with coops. need to see if we want to be coop provider. punted to bizdev
     - #372 set up telephone system: documentation required
 - Triage NEW tasks :new:
 	- ...

--- a/_posts/meeting-notes/2021-01-20-all-hands.md
+++ b/_posts/meeting-notes/2021-01-20-all-hands.md
@@ -56,42 +56,42 @@ Notetaker:  el :raising_hand: el, yj, uv, dc, pc, bl, gi
 ### Task Board Review
 
 - Archive DONE tasks :tada:
-	- #386
-	- #381
-	- #239
+	- [#386](https://github.com/hyphacoop/organizing/issues/386)
+	- [#381](https://github.com/hyphacoop/organizing/issues/381)
+	- [#239](https://github.com/hyphacoop/organizing/issues/239)
 	- private ???
-	- #329
+	- [#329](https://github.com/hyphacoop/organizing/issues/329)
 - Review [HIGH `[priority-★★★]`][l-pri-hi] tasks :fire:
-	- #313
+	- [#313](https://github.com/hyphacoop/organizing/issues/313)
 	    - CTF will circle back to it in infra
-	- #104
+	- [#104](https://github.com/hyphacoop/organizing/issues/104)
 	    - prep to sign everything using hellosign
 	    - will not accept PGP signature but allows text in hellosign
 	    - will only allow PDF
         - concern about hellosign digital date in file
 - Review [HIGH `[priority-★★☆]`][l-pri-md] tasks
-    - #382
+    - [#382](https://github.com/hyphacoop/organizing/issues/382)
         - bizdev working on this written first blog post
         - infra to help to launch
         - use dpress to publish
-    - #133
+    - [#133](https://github.com/hyphacoop/organizing/issues/133)
         - bl: not working on this anymore
-    - #307
+    - [#307](https://github.com/hyphacoop/organizing/issues/307)
         - dc: PR the handbook
-    - #298
+    - [#298](https://github.com/hyphacoop/organizing/issues/298)
         - documentation task
-    - #319
+    - [#319](https://github.com/hyphacoop/organizing/issues/319)
         - done
-    - #374
+    - [#374](https://github.com/hyphacoop/organizing/issues/374)
         - work with pc on this
-    - private#108
+    - [private#108](https://github.com/hyphacoop/organizing-private/issues/108)
         - pickup peer feedback
         - decision making
-    - #377
+    - [#377](https://github.com/hyphacoop/organizing/issues/377)
         - same as above
-    - private#43
+    - [private#43](https://github.com/hyphacoop/organizing-private/issues/43)
         - ...
-    - #217
+    - [#217](https://github.com/hyphacoop/organizing/issues/217)
         - need to do online training
 
 - Triage NEW tasks :new:

--- a/_posts/meeting-notes/2021-02-12-operations.md
+++ b/_posts/meeting-notes/2021-02-12-operations.md
@@ -39,7 +39,7 @@ Notetaker:  *
     - Equity4Who
         - We are holding until they get back to us
         - #todo:pc ~~followup on Wed~~
-        - #todo:pc ~~email forwarder for oc~~ [`private#116`](https://github.com/hyphacoop/organizing-private/pull/116)
+        - #todo:pc ~~email forwarder for oc~~ [private#116](https://github.com/hyphacoop/organizing-private/issues/116)
         - sample sheet: https://docs.google.com/spreadsheets/d/1oyUjNZHaslqu7E_VySMgj6C6AOpSeS63UCZNoVYAtjc/edit#gid=0
         - #todo:pc ~~make open collective project folder~~ [done](https://drive.google.com/drive/u/0/folders/1aAExZzaUZG7PzcF1PGVOJqg5xfhXTKIo)
         - #todo:pc remove hypha on other 
@@ -57,7 +57,7 @@ Notetaker:  *
         - CTTO outreach?
             - pc will keep announcing at CTTO +1 dc
         - #todo:pc debrief in 2 weeks Ops call (Feb 24)
-        - #todo:pc ~~create opp ticket~~ [`private#115`](https://github.com/hyphacoop/organizing-private/issues/115)
+        - #todo:pc ~~create opp ticket~~ [private#115](https://github.com/hyphacoop/organizing-private/issues/115)
     - ~~$500 marketing~~ (discussed in bizdev)
 - Transformation plan! (40 min)
     - notes in board

--- a/_posts/private/meeting-notes/2020-03-30-infrastructure.md
+++ b/_posts/private/meeting-notes/2020-03-30-infrastructure.md
@@ -34,14 +34,14 @@ _skipped_
 ### Task Board Review
 
 - Review DONE tasks :tada:
-	- #212 domains expired, close and archive
+	- [#212](https://github.com/hyphacoop/organizing/issues/212) domains expired, close and archive
 - Review [`[priority-★★★]`][l-pri-hi] [`[priority-★★☆]`][l-pri-md] [`[priority-★☆☆]`][l-pri-lo] [`[priority-none]`][l-pri-none]
-    - #244 hypha.coop renewal
+    - [#244](https://github.com/hyphacoop/organizing/issues/244) hypha.coop renewal
         - #todo:yj check on renewal and ensure it auto-renews 
 
 ### Discussions
 
-- #246 Big Blue Button
+- [#246](https://github.com/hyphacoop/organizing/issues/246) Big Blue Button
     - Data retention
         - yj: how do we delete things?
         - yj: **jitsi** we keep operating system "logs", pretty easy


### PR DESCRIPTION
Using the `make link-issues` script that will now be run on each new set of notes added: https://github.com/hyphacoop/organizing/pull/397