### PR TITLE
Use current year for links to meeting stubs/placeholders

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -33,15 +33,15 @@
     <li>
       <span class="small">
         Archive as
-        <a href="{{ site.public-repo-url }}/new/master?filename=_posts/meeting-notes/2021-MM-DD-.md" target="_blank">open access</a>
+        <a href="{{ site.public-repo-url }}/new/master?filename=_posts/meeting-notes/{{ site.time | date: '%Y' }}-MM-DD-.md" target="_blank">open access</a>
       </span>
     </li>
     <li>
       <span class="small">
         Archive as
-        <a href="{{ site.private-repo-url }}/new/master?filename=meeting-notes/2021-MM-DD-.md" target="_blank">restricted access</a>
+        <a href="{{ site.private-repo-url }}/new/master?filename=meeting-notes/{{ site.time | date: '%Y' }}-MM-DD-.md" target="_blank">restricted access</a>
         with
-        <a href="{{ site.public-repo-url }}/new/master?filename=_posts/private/meeting-notes/2021-MM-DD-.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
+        <a href="{{ site.public-repo-url }}/new/master?filename=_posts/private/meeting-notes/{{ site.time | date: '%Y' }}-MM-DD-.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
       </span>
     </li>
   </ul>
@@ -54,15 +54,15 @@
       <li>
         <span class="small">
           Archive as
-          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/{{ section.path }}2020-MM-DD-.md" target="_blank">open access</a>
+          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/{{ section.path }}{{ site.time | date: '%Y' }}-MM-DD-.md" target="_blank">open access</a>
         </span>
       </li>
       <li>
         <span class="small">
           Archive as
-          <a href="{{ site.private-repo-url }}/new/master?filename={{ section.path }}2020-MM-DD-.md" target="_blank">restricted access</a>
+          <a href="{{ site.private-repo-url }}/new/master?filename={{ section.path }}{{ site.time | date: '%Y' }}-MM-DD-.md" target="_blank">restricted access</a>
           with
-          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/{{ private_path }}2020-MM-DD-.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
+          <a href="{{ site.public-repo-url }}/new/master?filename=_posts/{{ private_path }}{{ site.time | date: '%Y' }}-MM-DD-.md&value={{ 'Empty file for public indexing of access-restricted file.' | uri_escape }}" target="_blank">public stub</a>
         </span>
       </li>
     </ul>


### PR DESCRIPTION
Small fix after realizing some of these were out of sync. This gets generated whenever site gets generated, so quite often for us :)