### PR TITLE
Use commonmark as markdown processor: enable autolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,8 @@ gem "jemoji", "~> 0.11.1"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
-  gem "jekyll-commonmark-ghpages", "~> 0.1.6"
+  gem "jekyll-commonmark-ghpages",
+    github: "hugmanrique/jekyll-commonmark-ghpages"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/hugmanrique/jekyll-commonmark-ghpages.git
+  revision: 86738bd7fda855c97d2789080d3876d9a3a1862a
+  specs:
+    jekyll-commonmark-ghpages (0.1.6)
+      commonmarker (~> 0.21)
+      jekyll-commonmark (~> 1.2)
+      rouge (>= 2.0, < 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -10,7 +19,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (0.21.2)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
     em-websocket (0.5.1)
@@ -44,10 +53,6 @@ GEM
     jekyll-commonmark (1.3.1)
       commonmarker (~> 0.14)
       jekyll (>= 3.7, < 5.0)
-    jekyll-commonmark-ghpages (0.1.6)
-      commonmarker (~> 0.17.6)
-      jekyll-commonmark (~> 1.2)
-      rouge (>= 2.0, < 4.0)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.1.0)
@@ -87,7 +92,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.4)
     rouge (3.16.0)
-    ruby-enum (0.7.2)
+    ruby-enum (0.9.0)
       i18n
     safe_yaml (1.0.5)
     sassc (2.2.1)
@@ -108,7 +113,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.0.0)
-  jekyll-commonmark-ghpages (~> 0.1.6)
+  jekyll-commonmark-ghpages!
   jekyll-feed (~> 0.12)
   jemoji (~> 0.11.1)
   minima (~> 2.5)

--- a/_config.yml
+++ b/_config.yml
@@ -35,18 +35,17 @@ plugins:
 
 # Allows full rendering with autolinks and tasklists.
 # See: https://github.com/github/jekyll-commonmark-ghpages#installation
-#markdown: CommonMarkGhPages
-
-#commonmark:
-#  options: ["SMART", "FOOTNOTES"]
-#  extensions:
-#    - "strikethrough"
-#    - "autolink"
-#    - "table"
-#    - "tagfilter"
-    # This will start working when commonmarker is upgraded.
+markdown: CommonMarkGhPages
+commonmark:
+  options: ["SMART", "FOOTNOTES"]
+  extensions:
+    - "strikethrough"
+    - "autolink"
+    - "table"
+    - "tagfilter"
+    # This works locally, and will start working on GitHub Pages when commonmarker version is loosened upstream.
     # See: https://github.com/github/jekyll-commonmark-ghpages/issues/13
-#    - "tasklist"
+    - "tasklist"
 
 permalink: /:categories/:year-:month-:day-:title:output_ext
 defaults:


### PR DESCRIPTION
We lost auto-links when migrating the the new meeting index format. (autolinks = GFM feature where bare links are made clickable.)

Example: https://meetings.hypha.coop/2021-02-22-ontario-coop-association.html (no links)

This brings it back. It should work fine on github pages.