### PR TITLE
Add link to layouts that allow quicklink to edit page on GitHub

### DIFF
--- a/_includes/edit-link.html
+++ b/_includes/edit-link.html
@@ -1,0 +1,5 @@
+<sub>
+  <a href="{{ site.public-repo-url }}/edit/master/{{ page.path }}">
+    Edit this page
+  </a>
+<sub>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@
 
         <div class="wrapper">
           {{ content }}
+          {%- include edit-link.html -%}
         </div>
 
     </main>

--- a/_layouts/private.html
+++ b/_layouts/private.html
@@ -12,6 +12,7 @@
             {% include private-redirect.html %}
           {%- endcapture %}
           {{ private-redirect | markdownify }}
+          {%- include edit-link.html -%}
         </div>
 
     </main>

--- a/_layouts/private.html
+++ b/_layouts/private.html
@@ -12,7 +12,6 @@
             {% include private-redirect.html %}
           {%- endcapture %}
           {{ private-redirect | markdownify }}
-          {%- include edit-link.html -%}
         </div>
 
     </main>


### PR DESCRIPTION
The following things are currently cumbersome:
- quick typo fixes
- quick renaming/re-titling
- changing note/stub from private to public (or vice verse)

This small addition of an "edit this page" link to the bottom of layouts would make the above simpler.

I think there's room for a better UI on this, but I'd like to request that this be part of later rejig of the meeting index. Being very pragmatic with this PR :)

## Screenshots

### Front page
<img width="1372" alt="Screen Shot 2021-03-30 at 12 55 20 PM" src="https://user-images.githubusercontent.com/305339/113026598-402ff880-9157-11eb-8a9d-8569b2c6f5ea.png">

### Private Stub
<img width="1416" alt="Screen Shot 2021-03-30 at 12 55 29 PM" src="https://user-images.githubusercontent.com/305339/113026614-42925280-9157-11eb-9283-303dce0fce73.png">

### Public Note
<img width="1368" alt="Screen Shot 2021-03-30 at 12 55 39 PM" src="https://user-images.githubusercontent.com/305339/113026617-432ae900-9157-11eb-9f61-2d2be2dd4cdb.png">
